### PR TITLE
add support for cockroachdb

### DIFF
--- a/src/helpers/generateFieldType.ts
+++ b/src/helpers/generateFieldType.ts
@@ -85,6 +85,8 @@ export const generateFieldTypeInner = (type: string, config: Config) => {
       return overrideType(type, config) || mysqlTypeMap[type];
     case "postgresql":
       return overrideType(type, config) || postgresqlTypeMap[type];
+    case "cockroachdb":
+      return overrideType(type, config) || postgresqlTypeMap[type];
   }
 };
 

--- a/src/utils/validateConfig.ts
+++ b/src/utils/validateConfig.ts
@@ -6,6 +6,7 @@ export const configValidator = z
     // Meta information (not provided through user input)
     databaseProvider: z.union([
       z.literal("postgresql"),
+      z.literal("cockroachdb"),
       z.literal("mysql"),
       z.literal("sqlite"),
     ]),


### PR DESCRIPTION
Fields in cockroachdb and postgresql are mostly interchangeable.
We can add a note in README stating that this support is in beta.