### PR TITLE
feat: pass prisma comments on field types to the generated TS types

### DIFF
--- a/.changeset/few-scissors-design.md
+++ b/.changeset/few-scissors-design.md
@@ -1,0 +1,5 @@
+---
+"prisma-kysely": minor
+---
+
+Pass Prisma comments on Prisma fields to the generated TypeScript types

--- a/src/helpers/generateField.test.ts
+++ b/src/helpers/generateField.test.ts
@@ -10,28 +10,52 @@ const stringTypeNode = ts.factory.createTypeReferenceNode(
 );
 
 test("it creates correct annotation for non-nullable types", () => {
-  const node = generateField("name", stringTypeNode, false, false, false);
+  const node = generateField({
+    name: "name",
+    type: stringTypeNode,
+    nullable: false,
+    generated: false,
+    list: false,
+  });
   const result = stringifyTsNode(node);
 
   expect(result).toEqual("name: string;");
 });
 
 test("it creates correct annotation for nullable types", () => {
-  const node = generateField("name", stringTypeNode, true, false, false);
+  const node = generateField({
+    name: "name",
+    type: stringTypeNode,
+    nullable: true,
+    generated: false,
+    list: false,
+  });
   const result = stringifyTsNode(node);
 
   expect(result).toEqual("name: string | null;");
 });
 
 test("it creates correct annotation for generated types", () => {
-  const node = generateField("name", stringTypeNode, false, true, false);
+  const node = generateField({
+    name: "name",
+    type: stringTypeNode,
+    nullable: false,
+    generated: true,
+    list: false,
+  });
   const result = stringifyTsNode(node);
 
   expect(result).toEqual("name: Generated<string>;");
 });
 
 test("it creates correct annotation for list types", () => {
-  const node = generateField("name", stringTypeNode, false, false, true);
+  const node = generateField({
+    name: "name",
+    type: stringTypeNode,
+    nullable: false,
+    generated: false,
+    list: true,
+  });
   const result = stringifyTsNode(node);
 
   expect(result).toEqual("name: string[];");
@@ -41,8 +65,28 @@ test("it creates correct annotation for generated nullable list types (do these 
   // Is this how these work? I have no clue. I don't even know if Kysely supports these.
   // If you run into problems here, please file an issue or create a pull request.
 
-  const node = generateField("name", stringTypeNode, true, true, true);
+  const node = generateField({
+    name: "name",
+    type: stringTypeNode,
+    nullable: true,
+    generated: true,
+    list: true,
+  });
   const result = stringifyTsNode(node);
 
   expect(result).toEqual("name: Generated<string | null>[];");
+});
+
+test("it prepends a JSDoc comment if documentation is provided", () => {
+  const node = generateField({
+    name: "name",
+    type: stringTypeNode,
+    nullable: false,
+    generated: false,
+    list: false,
+    documentation: "This is a comment",
+  });
+  const result = stringifyTsNode(node);
+
+  expect(result).toEqual("/** This is a comment */\nname: string;");
 });

--- a/src/helpers/generateField.test.ts
+++ b/src/helpers/generateField.test.ts
@@ -88,5 +88,5 @@ test("it prepends a JSDoc comment if documentation is provided", () => {
   });
   const result = stringifyTsNode(node);
 
-  expect(result).toEqual("/** This is a comment */\nname: string;");
+  expect(result).toEqual("/**\n * This is a comment\n */\nname: string;");
 });

--- a/src/helpers/generateField.ts
+++ b/src/helpers/generateField.ts
@@ -1,18 +1,22 @@
 import ts from "typescript";
 
-export const generateField = (
-  name: string,
-  type: ts.TypeNode,
-  nullable: boolean,
-  generated: boolean,
-  list: boolean
-) => {
+type GenerateFieldArgs = {
+  name: string;
+  type: ts.TypeNode;
+  nullable: boolean;
+  generated: boolean;
+  list: boolean;
+  documentation?: string;
+};
+export const generateField = (args: GenerateFieldArgs) => {
   /*
    * I'm not totally sure in which order these should be applied when it comes
    * to lists. Is the whole list nullable or is each entry in the list nullable?
    * If you run into problems here please file an issue or create a pull request
    * with a fix and some proof please. Thank you :D
    */
+
+  const { name, type, nullable, generated, list, documentation } = args;
 
   let fieldType = type;
 
@@ -32,10 +36,26 @@ export const generateField = (
 
   if (list) fieldType = ts.factory.createArrayTypeNode(fieldType);
 
-  return ts.factory.createPropertySignature(
+  const propertySignature = ts.factory.createPropertySignature(
     undefined,
     ts.factory.createIdentifier(name),
     undefined,
     fieldType
   );
+
+  if (documentation) {
+    return ts.addSyntheticLeadingComment(
+      propertySignature,
+      ts.SyntaxKind.MultiLineCommentTrivia,
+      // This is a bit hacky and I'm not sure if there's a better way to do this
+      // while returning a PropertySignature type.
+      // This methods results to: /*${documentation}*/
+      // Which is clearly not a JSDoc comment. So to get around it, we add a
+      // leading asterisk + surrounding spaces so the result is: /** ${documentation} */
+      `* ${documentation} `,
+      true
+    );
+  }
+
+  return propertySignature;
 };

--- a/src/helpers/generateField.ts
+++ b/src/helpers/generateField.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 
+import { applyJSDocWorkaround } from "~/utils/applyJSDocWorkaround";
 import isValidTSIdentifier from "~/utils/isValidTSIdentifier";
 
 type GenerateFieldArgs = {
@@ -53,12 +54,7 @@ export const generateField = (args: GenerateFieldArgs) => {
     return ts.addSyntheticLeadingComment(
       propertySignature,
       ts.SyntaxKind.MultiLineCommentTrivia,
-      // This is a bit hacky and I'm not sure if there's a better way to do this
-      // while returning a PropertySignature type.
-      // This methods results to: /*${documentation}*/
-      // Which is clearly not a JSDoc comment. So to get around it, we add a
-      // leading asterisk + surrounding spaces so the result is: /** ${documentation} */
-      `* ${documentation} `,
+      applyJSDocWorkaround(documentation),
       true
     );
   }

--- a/src/helpers/generateModel.ts
+++ b/src/helpers/generateModel.ts
@@ -25,7 +25,7 @@ export const generateModel = (model: DMMF.Model, config: Config) => {
 
     if (field.kind === "object" || field.kind === "unsupported") return [];
     if (field.kind === "enum") {
-      const x = generateField({
+      return generateField({
         name: field.name,
         type: ts.factory.createTypeReferenceNode(
           ts.factory.createIdentifier(field.type),
@@ -36,8 +36,6 @@ export const generateModel = (model: DMMF.Model, config: Config) => {
         list: field.isList,
         documentation: field.documentation,
       });
-
-      return x;
     }
 
     return generateField({

--- a/src/helpers/generateModel.ts
+++ b/src/helpers/generateModel.ts
@@ -24,28 +24,33 @@ export const generateModel = (model: DMMF.Model, config: Config) => {
       );
 
     if (field.kind === "object" || field.kind === "unsupported") return [];
-    if (field.kind === "enum")
-      return generateField(
-        field.name,
-        ts.factory.createTypeReferenceNode(
+    if (field.kind === "enum") {
+      const x = generateField({
+        name: field.name,
+        type: ts.factory.createTypeReferenceNode(
           ts.factory.createIdentifier(field.type),
           undefined
         ),
-        !field.isRequired,
-        isGenerated,
-        field.isList
-      );
+        nullable: !field.isRequired,
+        generated: isGenerated,
+        list: field.isList,
+        documentation: field.documentation,
+      });
 
-    return generateField(
-      normalizeCase(field.name, config),
-      ts.factory.createTypeReferenceNode(
+      return x;
+    }
+
+    return generateField({
+      name: normalizeCase(field.name, config),
+      type: ts.factory.createTypeReferenceNode(
         ts.factory.createIdentifier(generateFieldType(field.type, config)),
         undefined
       ),
-      !field.isRequired,
-      isGenerated,
-      field.isList
-    );
+      nullable: !field.isRequired,
+      generated: isGenerated,
+      list: field.isList,
+      documentation: field.documentation,
+    });
   });
 
   return {

--- a/src/utils/applyJSDocWorkaround.ts
+++ b/src/utils/applyJSDocWorkaround.ts
@@ -1,0 +1,3 @@
+export const applyJSDocWorkaround = (comment: string) => {
+  return `*\n * ${comment.split("\n").join("\n * ")}\n `;
+};


### PR DESCRIPTION
This PR Resolves #21 

Refactored `generateField` to accept an object instead since it's getting unwieldy using positional arguments especially when an optional parameter is involved.

@valtyr I'm not familiar working with the TS Compiler API so I wonder if there's an alternative to this. See comments on `generateField.ts`. `ts.addSyntheticLeadingComment`'s `kind` parameter only accepts `SingleLineCommentTrivia` or `MultiLineCommentTrivia` so we're stuck working with `// foo` and `/*foo*/` comments when using this method. There doesn't seem to be any other method we could use either that would still return a `PropertySignature` type.

![addSyntheticLeadingComment signature](https://user-images.githubusercontent.com/6721822/233614408-0f31a330-8a8e-443b-9e75-61465d625cd2.png)

I find the workaround ugly but it works.

Given this field:
![prisma field def](https://user-images.githubusercontent.com/6721822/233615031-c0e1cced-eff7-4662-9e8d-08a7ab0fedd2.png)

It renders this:
![ts result with the workaround](https://i.imgur.com/Nx5eLmC.gif)

Without the workaround, this is the output.
![ts result without the workaround](https://i.imgur.com/DYhphtz.gif)