### PR TITLE
Add support for generating enum objects

### DIFF
--- a/.changeset/nasty-experts-relax.md
+++ b/.changeset/nasty-experts-relax.md
@@ -1,0 +1,5 @@
+---
+"prisma-kysely": patch
+---
+
+Add object declarations for enums, that can be used (among other things) for runtime validation. Thanks @jvandenaardweg for the idea! 😎👍

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -7,11 +7,11 @@ import { generateDatabaseType } from "~/helpers/generateDatabaseType";
 import { generateFile } from "~/helpers/generateFile";
 import { generateImplicitManyToManyModels } from "~/helpers/generateImplicitManyToManyModels";
 import { generateModel } from "~/helpers/generateModel";
-import { generateStringLiteralUnion } from "~/helpers/generateStringLiteralUnion";
-import { generateTypedAliasDeclaration } from "~/helpers/generateTypedAliasDeclaration";
 import { sorted } from "~/utils/sorted";
 import { validateConfig } from "~/utils/validateConfig";
 import { writeFileSafely } from "~/utils/writeFileSafely";
+
+import { generateEnumType } from "./helpers/generateEnumType";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { version } = require("../package.json");
@@ -33,11 +33,7 @@ generatorHandler({
 
     // Generate enum types
     const enums = options.dmmf.datamodel.enums.flatMap(({ name, values }) => {
-      const type = generateStringLiteralUnion(values.map((v) => v.name));
-      if (!type) return [];
-
-      const declaration = generateTypedAliasDeclaration(name, type);
-      return declaration;
+      return generateEnumType(name, values);
     });
 
     // Generate DMMF models for implicit many to many tables

--- a/src/helpers/generateEnumType.ts
+++ b/src/helpers/generateEnumType.ts
@@ -1,0 +1,44 @@
+import type { DMMF } from "@prisma/generator-helper";
+import ts from "typescript";
+
+import isValidTSIdentifier from "~/utils/isValidTSIdentifier";
+
+import { generateStringLiteralUnion } from "./generateStringLiteralUnion";
+import { generateTypedAliasDeclaration } from "./generateTypedAliasDeclaration";
+
+export const generateEnumType = (name: string, values: DMMF.EnumValue[]) => {
+  const type = generateStringLiteralUnion(values.map((v) => v.name));
+
+  if (!type) return [];
+
+  const objectDeclaration = ts.factory.createVariableStatement(
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    ts.factory.createVariableDeclarationList(
+      [
+        ts.factory.createVariableDeclaration(
+          name,
+          undefined,
+          undefined,
+          ts.factory.createObjectLiteralExpression(
+            values.map((v) => {
+              const identifier = isValidTSIdentifier(v.name)
+                ? ts.factory.createIdentifier(v.name)
+                : ts.factory.createStringLiteral(v.name);
+
+              return ts.factory.createPropertyAssignment(
+                identifier,
+                ts.factory.createStringLiteral(v.name)
+              );
+            }),
+            true
+          )
+        ),
+      ],
+      ts.NodeFlags.Const
+    )
+  );
+
+  const typeDeclaration = generateTypedAliasDeclaration(name, type);
+
+  return [typeDeclaration, objectDeclaration];
+};


### PR DESCRIPTION
This PR adds support for generating object declarations for enums alongside the TypeScript types:

```prisma
enum WidgetType {
    Sprocket
    Printer
}
```

Translates to:

```ts
export type WidgetType = "Sprocket" | "Printer";

// The following is new:
export const WidgetType = {
  Sprocket: "Sprocket",
  Printer: "Printer",
};
```

This is based on a suggestion by @jvandenaardweg and would fix #27.