### PR TITLE
Export enums and related types like Prisma does

### DIFF
--- a/.changeset/ten-fans-vanish.md
+++ b/.changeset/ten-fans-vanish.md
@@ -2,4 +2,4 @@
 "prisma-kysely": patch
 ---
 
-Narrower types for native enums (Thank you @jvandenaardweg 🎉)
+Now using narrower types for enum objects bringing `prisma-kysely`'s enums in line with `prisma-client-js` (Thank you @jvandenaardweg 🎉)

--- a/.changeset/ten-fans-vanish.md
+++ b/.changeset/ten-fans-vanish.md
@@ -1,0 +1,5 @@
+---
+"prisma-kysely": patch
+---
+
+Narrower types for native enums (Thank you @jvandenaardweg 🎉)

--- a/src/__test__/e2e.test.ts
+++ b/src/__test__/e2e.test.ts
@@ -101,12 +101,12 @@ test(
     const enumFile = await fs.readFile("./prisma/generated/enums.ts", {
       encoding: "utf-8",
     });
-    expect(enumFile).toEqual(`export type TestEnum = "A" | "B" | "C";
-export const TestEnum = {
+    expect(enumFile).toEqual(`export const TestEnum = {
   A: "A",
   B: "B",
   C: "C",
 };
+export type TestEnum = (typeof TestEnum)[keyof typeof TestEnum];
 `);
   },
   { timeout: 20000 }

--- a/src/__test__/e2e.test.ts
+++ b/src/__test__/e2e.test.ts
@@ -105,7 +105,7 @@ test(
   A: "A",
   B: "B",
   C: "C",
-};
+} as const;
 export type TestEnum = (typeof TestEnum)[keyof typeof TestEnum];
 `);
   },

--- a/src/helpers/generateEnumType.test.ts
+++ b/src/helpers/generateEnumType.test.ts
@@ -1,0 +1,25 @@
+import ts, { createPrinter } from "typescript";
+import { expect, test } from "vitest";
+
+import { generateEnumType } from "./generateEnumType";
+
+test("it generates the enum type", () => {
+  const [objectDeclaration, typeDeclaration] = generateEnumType("Name", [
+    { name: "FOO", dbName: "FOO" },
+    { name: "BAR", dbName: "BAR" },
+  ]);
+
+  const printer = createPrinter();
+
+  const result = printer.printList(
+    ts.ListFormat.MultiLine,
+    ts.factory.createNodeArray([objectDeclaration, typeDeclaration]),
+    ts.createSourceFile("", "", ts.ScriptTarget.Latest)
+  );
+
+  expect(result).toEqual(`export const Name = {
+    FOO: "FOO",
+    BAR: "BAR"
+};
+export type Name = (typeof Name)[keyof typeof Name];\n`);
+});

--- a/src/helpers/generateEnumType.test.ts
+++ b/src/helpers/generateEnumType.test.ts
@@ -20,6 +20,6 @@ test("it generates the enum type", () => {
   expect(result).toEqual(`export const Name = {
     FOO: "FOO",
     BAR: "BAR"
-};
+} as const;
 export type Name = (typeof Name)[keyof typeof Name];\n`);
 });

--- a/src/helpers/generateEnumType.ts
+++ b/src/helpers/generateEnumType.ts
@@ -19,18 +19,25 @@ export const generateEnumType = (name: string, values: DMMF.EnumValue[]) => {
           name,
           undefined,
           undefined,
-          ts.factory.createObjectLiteralExpression(
-            values.map((v) => {
-              const identifier = isValidTSIdentifier(v.name)
-                ? ts.factory.createIdentifier(v.name)
-                : ts.factory.createStringLiteral(v.name);
 
-              return ts.factory.createPropertyAssignment(
-                identifier,
-                ts.factory.createStringLiteral(v.name)
-              );
-            }),
-            true
+          ts.factory.createAsExpression(
+            ts.factory.createObjectLiteralExpression(
+              values.map((v) => {
+                const identifier = isValidTSIdentifier(v.name)
+                  ? ts.factory.createIdentifier(v.name)
+                  : ts.factory.createStringLiteral(v.name);
+
+                return ts.factory.createPropertyAssignment(
+                  identifier,
+                  ts.factory.createStringLiteral(v.name)
+                );
+              }),
+              true
+            ),
+            ts.factory.createTypeReferenceNode(
+              ts.factory.createIdentifier("const"),
+              undefined
+            )
           )
         ),
       ],

--- a/src/helpers/generateEnumType.ts
+++ b/src/helpers/generateEnumType.ts
@@ -4,7 +4,7 @@ import ts from "typescript";
 import isValidTSIdentifier from "~/utils/isValidTSIdentifier";
 
 import { generateStringLiteralUnion } from "./generateStringLiteralUnion";
-import { generateTypedAliasDeclaration } from "./generateTypedAliasDeclaration";
+import { generateTypedReferenceNode } from "./generateTypedReferenceNode";
 
 export const generateEnumType = (name: string, values: DMMF.EnumValue[]) => {
   const type = generateStringLiteralUnion(values.map((v) => v.name));
@@ -38,7 +38,7 @@ export const generateEnumType = (name: string, values: DMMF.EnumValue[]) => {
     )
   );
 
-  const typeDeclaration = generateTypedAliasDeclaration(name, type);
+  const typeDeclaration = generateTypedReferenceNode(name);
 
-  return [typeDeclaration, objectDeclaration];
+  return [objectDeclaration, typeDeclaration];
 };

--- a/src/helpers/generateTypedReferenceNode.test.ts
+++ b/src/helpers/generateTypedReferenceNode.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "vitest";
+
+import { stringifyTsNode } from "~/utils/testUtils";
+
+import { generateTypedReferenceNode } from "./generateTypedReferenceNode";
+
+test("it creates correct annotation for non-nullable types", () => {
+  const node = generateTypedReferenceNode("Name");
+
+  const result = stringifyTsNode(node);
+
+  expect(result).toEqual(
+    "export type Name = (typeof Name)[keyof typeof Name];"
+  );
+});

--- a/src/helpers/generateTypedReferenceNode.test.ts
+++ b/src/helpers/generateTypedReferenceNode.test.ts
@@ -4,7 +4,7 @@ import { stringifyTsNode } from "~/utils/testUtils";
 
 import { generateTypedReferenceNode } from "./generateTypedReferenceNode";
 
-test("it creates correct annotation for non-nullable types", () => {
+test("it generated the typed reference node", () => {
   const node = generateTypedReferenceNode("Name");
 
   const result = stringifyTsNode(node);

--- a/src/helpers/generateTypedReferenceNode.ts
+++ b/src/helpers/generateTypedReferenceNode.ts
@@ -1,0 +1,14 @@
+import ts from "typescript";
+
+export const generateTypedReferenceNode = (name: string) => {
+  return ts.factory.createTypeAliasDeclaration(
+    undefined,
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    name,
+    undefined,
+    ts.factory.createTypeReferenceNode(
+      `(typeof ${name})[keyof typeof ${name}]`,
+      undefined
+    )
+  );
+};


### PR DESCRIPTION
I noticed the PR https://github.com/valtyr/prisma-kysely/pull/29 fixing issue https://github.com/valtyr/prisma-kysely/issues/27 wasn't really doing it for me. Back then didn't had the time to look into fixing it, so I ignored it and kept using the types from the Prisma client.

With the current export, the enum values are seen as a `string` instead of their value, like `"NL"`, even in a zod schema like:

```typescript
import { Language } from './types';

const currentLanguage = Language.NL // string

const schema = z.object({
  language: z.nativeEnum(Language)
  // language = { NL: string, EN: string }
});

export type SchemaLanguage = z.infer<typeof schema>['language'];

// type SchemaLanguage = string
 ```

This PR fixes that by exporting the enum's [exactly](https://github.com/prisma/prisma/blob/ccf3df016e80fe72ba567f54a9c669ce2b926c9a/packages/client/src/generation/TSClient/Enum.ts#L40) like Prisma does it, requiring no additional changes to code that uses the enum types and values from the Prisma client. So making the switch to Kysely even easier.

So, in summary, this PR generates:

```typescript
export const Language = {
  NL: "NL",
  EN: "EN",
};
export type Language = (typeof Language)[keyof typeof Language];
```

instead of:
```typescript
export const Language = {
  NL: "NL",
  EN: "EN",
};
export type Language = 'NL' | 'EN';
```

So we get this working correctly:

```typescript
import { Language } from './types';

const currentLanguage = Language.NL // "NL"

const schema = z.object({
  language: z.nativeEnum(Language)
  // language = { NL: "NL", EN: "EN"}
});

export type SchemaLanguage = z.infer<typeof schema>['language'];

// type SchemaLanguage = "NL" | "EN"
 ```