### PR TITLE
If present use @map value from Prisma enums

### DIFF
--- a/.changeset/clever-yaks-attend.md
+++ b/.changeset/clever-yaks-attend.md
@@ -1,0 +1,5 @@
+---
+"prisma-kysely": minor
+---
+
+Support @map statement for enum values (Thank you @jvandenaardweg 🔥🇳🇱)

--- a/src/helpers/generateEnumType.ts
+++ b/src/helpers/generateEnumType.ts
@@ -27,7 +27,8 @@ export const generateEnumType = (name: string, values: DMMF.EnumValue[]) => {
 
               return ts.factory.createPropertyAssignment(
                 identifier,
-                ts.factory.createStringLiteral(v.name)
+                // dbName holds the "@map("value")" value from the Prisma schema if it exists, otherwise fallback to the name
+                ts.factory.createStringLiteral(v.dbName || v.name)
               );
             }),
             true

--- a/src/helpers/generatedEnumType.test.ts
+++ b/src/helpers/generatedEnumType.test.ts
@@ -1,0 +1,46 @@
+import ts, { createPrinter } from "typescript";
+import { expect, test } from "vitest";
+
+import { generateEnumType } from "./generateEnumType";
+
+test("it generates the enum type", () => {
+  const [objectDeclaration, typeDeclaration] = generateEnumType("Name", [
+    { name: "FOO", dbName: "FOO" },
+    { name: "BAR", dbName: "BAR" },
+  ]);
+
+  const printer = createPrinter();
+
+  const result = printer.printList(
+    ts.ListFormat.MultiLine,
+    ts.factory.createNodeArray([objectDeclaration, typeDeclaration]),
+    ts.createSourceFile("", "", ts.ScriptTarget.Latest)
+  );
+
+  expect(result).toEqual(`export type Name = "FOO" | "BAR";
+export const Name = {
+    FOO: "FOO",
+    BAR: "BAR"
+};\n`);
+});
+
+test("it generates the enum type when using Prisma's @map()", () => {
+  const [objectDeclaration, typeDeclaration] = generateEnumType("Name", [
+    { name: "FOO", dbName: "foo" },
+    { name: "BAR", dbName: "bar" },
+  ]);
+
+  const printer = createPrinter();
+
+  const result = printer.printList(
+    ts.ListFormat.MultiLine,
+    ts.factory.createNodeArray([objectDeclaration, typeDeclaration]),
+    ts.createSourceFile("", "", ts.ScriptTarget.Latest)
+  );
+
+  expect(result).toEqual(`export type Name = "FOO" | "BAR";
+export const Name = {
+    FOO: "foo",
+    BAR: "bar"
+};\n`);
+});

--- a/src/helpers/generatedEnumType.test.ts
+++ b/src/helpers/generatedEnumType.test.ts
@@ -17,11 +17,11 @@ test("it generates the enum type", () => {
     ts.createSourceFile("", "", ts.ScriptTarget.Latest)
   );
 
-  expect(result).toEqual(`export type Name = "FOO" | "BAR";
-export const Name = {
+  expect(result).toEqual(`export const Name = {
     FOO: "FOO",
     BAR: "BAR"
-};\n`);
+} as const;
+export type Name = (typeof Name)[keyof typeof Name];\n`);
 });
 
 test("it generates the enum type when using Prisma's @map()", () => {
@@ -38,9 +38,9 @@ test("it generates the enum type when using Prisma's @map()", () => {
     ts.createSourceFile("", "", ts.ScriptTarget.Latest)
   );
 
-  expect(result).toEqual(`export type Name = "FOO" | "BAR";
-export const Name = {
+  expect(result).toEqual(`export const Name = {
     FOO: "foo",
     BAR: "bar"
-};\n`);
+} as const;
+export type Name = (typeof Name)[keyof typeof Name];\n`);
 });


### PR DESCRIPTION
Fixes: https://github.com/valtyr/prisma-kysely/issues/37


Without this PR:
```typescript
export type CountryCode = "AD" | "AE";
export const CountryCode = {
  AD: "AD",
  AE: "AE",
};
export type Religion = "BUDDHISM" | "CATHOLICISM" | "CHRISTIANITY";
export const Religion = {
  BUDDHISM: "BUDDHISM",
  CATHOLICISM: "CATHOLICISM",
  CHRISTIANITY: "CHRISTIANITY",
};

```

With this PR:
```typescript
export type CountryCode = "AD" | "AE";
export const CountryCode = {
  AD: "AD",
  AE: "AE",
};
export type Religion = "BUDDHISM" | "CATHOLICISM" | "CHRISTIANITY";
export const Religion = {
  BUDDHISM: "buddhism",
  CATHOLICISM: "catholicism",
  CHRISTIANITY: "christianity",
};
```