### PR TITLE
Use the value of `fileName` when no `enumFileName` provided. Add `GeneratedAlways` only when needed. 

### DIFF
--- a/.changeset/warm-radios-greet.md
+++ b/.changeset/warm-radios-greet.md
@@ -1,0 +1,6 @@
+---
+"prisma-kysely": patch
+---
+
+- use the value of fileName when no enumFileName provided. Right now if you use a different fileName and you don't provide enumFileName it will put database in the fileName and enums in types.ts.
+- add GeneratedAlways only when needed. Right now it's always added, even if not needed which causes problems with linter.

--- a/src/helpers/generateFile.ts
+++ b/src/helpers/generateFile.ts
@@ -19,7 +19,9 @@ export const generateFile = (
 
   const result = printer.printFile(file);
 
-  const leader = `import type { ColumnType, GeneratedAlways } from "kysely";
+  const leader = `import type { ColumnType${
+    result.includes("GeneratedAlways") ? ", GeneratedAlways" : ""
+  } } from "kysely";
 export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
   ? ColumnType<S, I | undefined, U>
   : ColumnType<T, T | undefined, T>;

--- a/src/utils/validateConfig.ts
+++ b/src/utils/validateConfig.ts
@@ -20,7 +20,7 @@ export const configValidator = z
 
     // Output overrides
     fileName: z.string().optional().default("types.ts"),
-    enumFileName: z.string().optional().default("types.ts"),
+    enumFileName: z.string().optional(),
 
     // Typescript type overrides
     stringTypeOverride: z.string().optional(),
@@ -40,7 +40,14 @@ export const configValidator = z
     // Use GeneratedAlways for IDs instead of Generated
     readOnlyIds: booleanStringLiteral.default(false),
   })
-  .strict();
+  .strict()
+  .transform((config) => {
+    if (!config.enumFileName) {
+      config.enumFileName = config.fileName;
+    }
+    return config as Omit<typeof config, "enumFileName"> &
+      Required<Pick<typeof config, "enumFileName">>;
+  });
 
 export type Config = z.infer<typeof configValidator>;
 


### PR DESCRIPTION
This PR changes two things:
* Use the value of `fileName` when no `enumFileName` provided. Right now if you use a different `fileName` and you don't provide `enumFileName` it will put database in the `fileName` and enums in `types.ts`.
* Add `GeneratedAlways` only when needed. Right now it's always added, even if not needed which causes problems with linter. 