### PR TITLE
Per-field type overrides

### DIFF
--- a/.changeset/fuzzy-dolphins-hide.md
+++ b/.changeset/fuzzy-dolphins-hide.md
@@ -1,0 +1,5 @@
+---
+"prisma-kysely": patch
+---
+
+Adds per field type overrides

--- a/README.md
+++ b/README.md
@@ -83,6 +83,40 @@ hope it's just as useful for you! 😎
 | `readOnlyIds`            | Use Kysely's `GeneratedAlways` for `@id` fields with default values, preventing insert and update.                                                                                                                                                                                                                                                                                  |
 | `[typename]TypeOverride` | Allows you to override the resulting TypeScript type for any Prisma type. Useful when targeting a different environment than Node (e.g. WinterCG compatible runtimes that use UInt8Arrays instead of Buffers for binary types etc.) Check out the [config validator](https://github.com/valtyr/prisma-kysely/blob/main/src/utils/validateConfig.ts) for a complete list of options. |
 
+### Per-field type overrides
+
+In some cases, you might want to override a type for a specific field. This
+could be useful, for example, for constraining string types to certain literal
+values. Be aware though that this does not of course come with any runtime
+validation, and in most cases won't be guaranteed to match the actual data in
+the database.
+
+That disclaimer aside, here's how it works: Add a `@kyselyType(...)` declaration
+to the Prisma docstring (deliniated using three slashes `///`) for the field
+with your type inside the parentheses.
+
+```prisma
+model User {
+  id          String @id
+  name        String
+
+  /// @kyselyType('member' | 'admin')
+  role        String
+}
+```
+
+The parentheses can include any valid TS type declaration.
+
+The output for the example above would be as follows:
+
+```ts
+export type User = {
+  id: string;
+  name: string;
+  role: "member" | "owner";
+};
+```
+
 ### Gotchas
 
 #### Default values

--- a/src/__test__/e2e.test.ts
+++ b/src/__test__/e2e.test.ts
@@ -95,7 +95,7 @@ test(
         id          String @id
         name        String
 
-        /// @typeOverride('member' | 'owner')
+        /// @kyselyType('member' | 'owner')
         role        String
     }`
     );
@@ -113,7 +113,7 @@ test(
   id: string;
   name: string;
   /**
-   * @typeOverride('member' | 'owner')
+   * @kyselyType('member' | 'owner')
    */
   role: "member" | "owner";
 };`)

--- a/src/__test__/e2e.test.ts
+++ b/src/__test__/e2e.test.ts
@@ -74,6 +74,55 @@ test(
 );
 
 test(
+  "End to end test - with custom type override",
+  async () => {
+    // Initialize prisma:
+    await exec("yarn prisma init --datasource-provider sqlite");
+
+    // Set up a schema
+    await fs.writeFile(
+      "./prisma/schema.prisma",
+      `datasource db {
+        provider = "sqlite"
+        url      = "file:./dev.db"
+    }
+
+    generator kysely {
+        provider  = "node ./dist/bin.js"
+    }
+    
+    model TestUser {
+        id          String @id
+        name        String
+
+        /// @typeOverride('member' | 'owner')
+        role        String
+    }`
+    );
+
+    // Run Prisma commands without fail
+    await exec("yarn prisma generate");
+
+    const generatedSource = await fs.readFile("./prisma/generated/types.ts", {
+      encoding: "utf-8",
+    });
+
+    // Expect many to many models to have been generated
+    expect(
+      generatedSource.includes(`export type TestUser = {
+  id: string;
+  name: string;
+  /**
+   * @typeOverride('member' | 'owner')
+   */
+  role: "member" | "owner";
+};`)
+    ).toBeTruthy();
+  },
+  { timeout: 20000 }
+);
+
+test(
   "End to end test - separate entrypoints",
   async () => {
     // Initialize prisma:

--- a/src/helpers/generateFieldType.ts
+++ b/src/helpers/generateFieldType.ts
@@ -77,21 +77,33 @@ export const overrideType = (type: string, config: Config) => {
   }
 };
 
-export const generateFieldTypeInner = (type: string, config: Config) => {
+export const generateFieldTypeInner = (
+  type: string,
+  config: Config,
+  typeOverride: string | null
+) => {
   switch (config.databaseProvider) {
     case "sqlite":
-      return overrideType(type, config) || sqliteTypeMap[type];
+      return typeOverride || overrideType(type, config) || sqliteTypeMap[type];
     case "mysql":
-      return overrideType(type, config) || mysqlTypeMap[type];
+      return typeOverride || overrideType(type, config) || mysqlTypeMap[type];
     case "postgresql":
-      return overrideType(type, config) || postgresqlTypeMap[type];
+      return (
+        typeOverride || overrideType(type, config) || postgresqlTypeMap[type]
+      );
     case "cockroachdb":
-      return overrideType(type, config) || postgresqlTypeMap[type];
+      return (
+        typeOverride || overrideType(type, config) || postgresqlTypeMap[type]
+      );
   }
 };
 
-export const generateFieldType = (type: string, config: Config) => {
-  const fieldType = generateFieldTypeInner(type, config);
+export const generateFieldType = (
+  type: string,
+  config: Config,
+  typeOverride?: string | null
+) => {
+  const fieldType = generateFieldTypeInner(type, config, typeOverride || null);
   if (!fieldType)
     throw new Error(
       `Unsupported type ${type} for database ${config.databaseProvider}`

--- a/src/helpers/generateModel.ts
+++ b/src/helpers/generateModel.ts
@@ -3,7 +3,7 @@ import ts from "typescript";
 
 import { generateField } from "~/helpers/generateField";
 import { generateFieldType } from "~/helpers/generateFieldType";
-import { generateTypeOverrideFromDocumentation } from "~/utils/generateTypeOverrideFromDocumentation";
+import { generateTypeOverrideFromDocumentation } from "~/helpers/generateTypeOverrideFromDocumentation";
 import { normalizeCase } from "~/utils/normalizeCase";
 import type { Config } from "~/utils/validateConfig";
 

--- a/src/helpers/generateModel.ts
+++ b/src/helpers/generateModel.ts
@@ -3,6 +3,7 @@ import ts from "typescript";
 
 import { generateField } from "~/helpers/generateField";
 import { generateFieldType } from "~/helpers/generateFieldType";
+import { generateTypeOverrideFromDocumentation } from "~/utils/generateTypeOverrideFromDocumentation";
 import { normalizeCase } from "~/utils/normalizeCase";
 import type { Config } from "~/utils/validateConfig";
 
@@ -22,6 +23,10 @@ export const generateModel = (model: DMMF.Model, config: Config) => {
         "name" in field.default &&
         defaultTypesImplementedInJS.includes(field.default.name)
       );
+
+    const typeOverride = field.documentation
+      ? generateTypeOverrideFromDocumentation(field.documentation)
+      : null;
 
     if (field.kind === "object" || field.kind === "unsupported") return [];
     if (field.kind === "enum") {
@@ -44,7 +49,9 @@ export const generateModel = (model: DMMF.Model, config: Config) => {
     return generateField({
       name: normalizeCase(dbName || field.name, config),
       type: ts.factory.createTypeReferenceNode(
-        ts.factory.createIdentifier(generateFieldType(field.type, config)),
+        ts.factory.createIdentifier(
+          generateFieldType(field.type, config, typeOverride)
+        ),
         undefined
       ),
       nullable: !field.isRequired,

--- a/src/helpers/generateTypeOverrideFromDocumentation.test.ts
+++ b/src/helpers/generateTypeOverrideFromDocumentation.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "vitest";
+
+import { generateTypeOverrideFromDocumentation } from "./generateTypeOverrideFromDocumentation";
+
+test("finds a type override", () => {
+  const docString =
+    "this is some property \n here is the type override @typeOverride('admin' | 'member') ";
+
+  expect(generateTypeOverrideFromDocumentation(docString)).toEqual(
+    "'admin' | 'member'"
+  );
+});
+
+test("supports parentheses in type", () => {
+  const docString =
+    "this is some property \n here is the type override @typeOverride(('admin' | 'member')) ";
+
+  expect(generateTypeOverrideFromDocumentation(docString)).toEqual(
+    "('admin' | 'member')"
+  );
+});
+
+test("reacts correctly to unbalanced parens", () => {
+  const docString =
+    "this is some property \n here is the type override @typeOverride(('admin' | 'member') ";
+
+  expect(generateTypeOverrideFromDocumentation(docString)).toEqual(null);
+});
+
+test("reacts correctly to extra parens", () => {
+  const docString =
+    "this is some property \n here is the type override @typeOverride(('admin' | 'member'))) ";
+
+  expect(generateTypeOverrideFromDocumentation(docString)).toEqual(
+    "('admin' | 'member')"
+  );
+});
+
+test("finds type following incomplete one", () => {
+  const docString =
+    "this is some property \n here is the type @typeOverride( override @typeOverride('admin' | 'member') ";
+
+  expect(generateTypeOverrideFromDocumentation(docString)).toEqual(
+    "'admin' | 'member'"
+  );
+});
+
+test("doesn't do anything in case of no type", () => {
+  const docString = "this is some property with no override";
+
+  expect(generateTypeOverrideFromDocumentation(docString)).toEqual(null);
+});
+
+test("bails when we have an at sign and no match", () => {
+  const docString = "hit me up at squiggly@goofy.af";
+
+  expect(generateTypeOverrideFromDocumentation(docString)).toEqual(null);
+});

--- a/src/helpers/generateTypeOverrideFromDocumentation.test.ts
+++ b/src/helpers/generateTypeOverrideFromDocumentation.test.ts
@@ -4,7 +4,7 @@ import { generateTypeOverrideFromDocumentation } from "./generateTypeOverrideFro
 
 test("finds a type override", () => {
   const docString =
-    "this is some property \n here is the type override @typeOverride('admin' | 'member') ";
+    "this is some property \n here is the type override @kyselyType('admin' | 'member') ";
 
   expect(generateTypeOverrideFromDocumentation(docString)).toEqual(
     "'admin' | 'member'"
@@ -13,7 +13,7 @@ test("finds a type override", () => {
 
 test("supports parentheses in type", () => {
   const docString =
-    "this is some property \n here is the type override @typeOverride(('admin' | 'member')) ";
+    "this is some property \n here is the type override @kyselyType(('admin' | 'member')) ";
 
   expect(generateTypeOverrideFromDocumentation(docString)).toEqual(
     "('admin' | 'member')"
@@ -22,14 +22,14 @@ test("supports parentheses in type", () => {
 
 test("reacts correctly to unbalanced parens", () => {
   const docString =
-    "this is some property \n here is the type override @typeOverride(('admin' | 'member') ";
+    "this is some property \n here is the type override @kyselyType(('admin' | 'member') ";
 
   expect(generateTypeOverrideFromDocumentation(docString)).toEqual(null);
 });
 
 test("reacts correctly to extra parens", () => {
   const docString =
-    "this is some property \n here is the type override @typeOverride(('admin' | 'member'))) ";
+    "this is some property \n here is the type override @kyselyType(('admin' | 'member'))) ";
 
   expect(generateTypeOverrideFromDocumentation(docString)).toEqual(
     "('admin' | 'member')"
@@ -38,7 +38,7 @@ test("reacts correctly to extra parens", () => {
 
 test("finds type following incomplete one", () => {
   const docString =
-    "this is some property \n here is the type @typeOverride( override @typeOverride('admin' | 'member') ";
+    "this is some property \n here is the type @kyselyType( override @kyselyType('admin' | 'member') ";
 
   expect(generateTypeOverrideFromDocumentation(docString)).toEqual(
     "'admin' | 'member'"

--- a/src/helpers/generateTypeOverrideFromDocumentation.ts
+++ b/src/helpers/generateTypeOverrideFromDocumentation.ts
@@ -1,0 +1,73 @@
+const START_LEXEME = "@typeOverride(";
+
+/**
+ * Searches the field for a string matching @typeOverride(...) and uses
+ * that as the typescript type of the field.
+ *
+ * @param documentation - The documentation string of the field
+ * @returns
+ */
+export const generateTypeOverrideFromDocumentation = (
+  documentation: string
+) => {
+  const tokens = documentation.split("");
+
+  let matchState: { tokens: string[]; startLocation: number } | null = null;
+  let parentheses = 0;
+  let i = 0;
+  while (i < documentation.length) {
+    const currentToken = tokens[i];
+
+    // If we're working on a match
+    if (matchState) {
+      // If we're working on a match and we find the end
+      // return the result.
+      if (currentToken === ")" && parentheses === 0)
+        return matchState.tokens.join("");
+
+      // Increment or decrement the parentheses counter
+      // if we reach parentheses
+      if (currentToken === ")") parentheses--;
+      if (currentToken === "(") parentheses++;
+
+      // Append the current token to the match state.
+      matchState.tokens.push(currentToken);
+
+      i++;
+
+      // If we've reached the end of the documentaion
+      // without a match we should bail and continue
+      // scanning.
+      if (i === documentation.length) {
+        i = matchState.startLocation + 1;
+        matchState = null;
+        continue;
+      }
+
+      continue;
+    }
+
+    // If we find the beginning of the start lexeme
+    // we can continue checking for the full lexeme
+    if (currentToken === "@") {
+      const isMatch =
+        tokens.slice(i, i + START_LEXEME.length).join("") === START_LEXEME;
+
+      // If we don't find a match we bail.
+      if (!isMatch) {
+        i++;
+        continue;
+      }
+
+      // Else start checking for the rest of the match
+      matchState = { tokens: [], startLocation: i };
+      i += START_LEXEME.length;
+
+      continue;
+    }
+
+    i++;
+  }
+
+  return null;
+};

--- a/src/helpers/generateTypeOverrideFromDocumentation.ts
+++ b/src/helpers/generateTypeOverrideFromDocumentation.ts
@@ -1,7 +1,7 @@
-const START_LEXEME = "@typeOverride(";
+const START_LEXEME = "@kyselyType(";
 
 /**
- * Searches the field for a string matching @typeOverride(...) and uses
+ * Searches the field for a string matching @kyselyType(...) and uses
  * that as the typescript type of the field.
  *
  * @param documentation - The documentation string of the field


### PR DESCRIPTION
Here's an experiment I'd love feedback on. This enables overriding field types using the following pattern in Prisma docstrings.


```prisma
model TestUser {
    id          String @id
    name        String

    /// @kyselyType('member' | 'owner')
    role        String
}
```

I'll create a snapshot if anyone wants to try it out. This should allow for total flexibility. Be aware that there's no guarantee in the case above for example that the actual result will be valid. This might be useful people who use SQLite for example, and want to emulate enums.