### PR TITLE
Support Prisma's `multiSchema` feature via workaround

### DIFF
--- a/.changeset/eleven-tips-cry.md
+++ b/.changeset/eleven-tips-cry.md
@@ -1,0 +1,5 @@
+---
+"prisma-kysely": minor
+---
+
+Support `multiSchema` preview feature.

--- a/.changeset/eleven-tips-cry.md
+++ b/.changeset/eleven-tips-cry.md
@@ -2,4 +2,4 @@
 "prisma-kysely": minor
 ---
 
-Support `multiSchema` preview feature.
+Support `multiSchema` preview feature. (Thanks to @duniul 🇸🇪🪅)

--- a/.changeset/modern-ghosts-grow.md
+++ b/.changeset/modern-ghosts-grow.md
@@ -2,4 +2,4 @@
 "prisma-kysely": patch
 ---
 
-Respect mapped names for fields with enum types
+Respect mapped names for fields with enum types. (Thank you @fehnomenal 🇩🇪🎉)

--- a/.changeset/seven-panthers-judge.md
+++ b/.changeset/seven-panthers-judge.md
@@ -2,4 +2,4 @@
 "prisma-kysely": patch
 ---
 
-Sort DB properties by table name instead of type name.
+Sort DB properties by table name instead of type name. (Thank you @duniul 🇸🇪🪅)

--- a/.changeset/seven-panthers-judge.md
+++ b/.changeset/seven-panthers-judge.md
@@ -1,0 +1,5 @@
+---
+"prisma-kysely": patch
+---
+
+Sort DB properties by table name instead of type name.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "edit": "code ."
   },
   "dependencies": {
+    "@mrleebo/prisma-ast": "^0.6.0",
     "@prisma/generator-helper": "4.13.0",
     "@prisma/internals": "4.13.0",
     "typescript": "4.6.2",

--- a/src/__test__/e2e.test.ts
+++ b/src/__test__/e2e.test.ts
@@ -179,3 +179,57 @@ test(
   },
   { timeout: 20000 }
 );
+
+test(
+  "End to end test - multi-schema support",
+  async () => {
+    // Initialize prisma:
+    await exec("yarn prisma init --datasource-provider postgresql");
+
+    // Set up a schema
+    await fs.writeFile(
+      "./prisma/schema.prisma",
+      `generator kysely {
+        provider  = "node ./dist/bin.js"
+        previewFeatures = ["multiSchema"]
+    }
+    
+    datasource db {
+        provider = "postgresql"
+        schemas  = ["mammals", "birds"]
+        url      = env("TEST_DATABASE_URL")
+    }
+    
+    model Elephant {
+        id   Int    @id
+        name String
+    
+        @@map("elephants")
+        @@schema("mammals")
+    }
+    
+    model Eagle {
+        id   Int    @id
+        name String
+    
+        @@map("eagles")
+        @@schema("birds")
+    }`
+    );
+
+    await exec("yarn prisma generate");
+
+    // Shouldn't have an empty import statement
+    const typeFile = await fs.readFile("./prisma/generated/types.ts", {
+      encoding: "utf-8",
+    });
+
+    console.log(typeFile);
+
+    expect(typeFile).toContain(`export type DB = {
+  "birds.eagles": Eagle;
+  "mammals.elephants": Elephant;
+};`);
+  },
+  { timeout: 20000 }
+);

--- a/src/__test__/e2e.test.ts
+++ b/src/__test__/e2e.test.ts
@@ -224,8 +224,6 @@ test(
       encoding: "utf-8",
     });
 
-    console.log(typeFile);
-
     expect(typeFile).toContain(`export type DB = {
   "birds.eagles": Eagle;
   "mammals.elephants": Elephant;

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -12,6 +12,7 @@ import { validateConfig } from "~/utils/validateConfig";
 import { writeFileSafely } from "~/utils/writeFileSafely";
 
 import { generateEnumType } from "./helpers/generateEnumType";
+import { convertToMultiSchemaModels } from "./helpers/multiSchemaHelpers";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { version } = require("../package.json");
@@ -45,10 +46,15 @@ generatorHandler({
     );
 
     // Generate model types
-    const models = sorted(
+    let models = sorted(
       [...options.dmmf.datamodel.models, ...implicitManyToManyModels],
       (a, b) => a.name.localeCompare(b.name)
     ).map((m) => generateModel(m, config));
+
+    // Extend model table names with schema names if using multi-schemas
+    if (options.generator.previewFeatures?.includes("multiSchema")) {
+      models = convertToMultiSchemaModels(models, options.datamodel);
+    }
 
     // Generate the database type that ties it all together
     const databaseType = generateDatabaseType(

--- a/src/helpers/generateDatabaseType.test.ts
+++ b/src/helpers/generateDatabaseType.test.ts
@@ -70,7 +70,7 @@ test("it works for table names with spaces and weird symbols", () => {
 
   expect(result).toEqual(`export type DB = {
     Bookmark: Bookmark;
-    "user session_*table ;D": Session;
     User: User;
+    "user session_*table ;D": Session;
 };`);
 });

--- a/src/helpers/generateDatabaseType.ts
+++ b/src/helpers/generateDatabaseType.ts
@@ -2,13 +2,18 @@ import ts from "typescript";
 
 import isValidTSIdentifier from "~/utils/isValidTSIdentifier";
 import { normalizeCase } from "~/utils/normalizeCase";
+import { sorted } from "~/utils/sorted";
 import type { Config } from "~/utils/validateConfig";
 
 export const generateDatabaseType = (
   models: { tableName: string; typeName: string }[],
   config: Config
 ) => {
-  const properties = models.map((field) => {
+  const sortedModels = sorted(models, (a, b) =>
+    a.tableName.localeCompare(b.tableName)
+  );
+
+  const properties = sortedModels.map((field) => {
     const caseNormalizedTableName = normalizeCase(field.tableName, config);
 
     /*

--- a/src/helpers/multiSchemaHelpers.test.ts
+++ b/src/helpers/multiSchemaHelpers.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "vitest";
+
+import { convertToMultiSchemaModels } from "./multiSchemaHelpers";
+
+const testDataModel = `generator kysely {
+  provider        = "node ./dist/bin.js"
+  previewFeatures = ["multiSchema"]
+}
+
+datasource db {
+  provider = "postgresql"
+  schemas  = ["mammals", "birds"]
+  url      = env("TEST_DATABASE_URL")
+}
+
+model Elephant {
+  id   Int    @id
+  name String
+
+  @@map("elephants")
+  @@schema("mammals")
+}
+
+model Eagle {
+  id   Int    @id
+  name String
+
+  @@map("eagles")
+  @@schema("birds")
+}`;
+
+test("returns a list of models with schemas appended to the table name", () => {
+  const initialModels = [
+    { typeName: "Elephant", tableName: "elephants" },
+    { typeName: "Eagle", tableName: "eagles" },
+  ];
+
+  const result = convertToMultiSchemaModels(initialModels, testDataModel);
+
+  expect(result).toEqual([
+    { typeName: "Elephant", tableName: "mammals.elephants" },
+    { typeName: "Eagle", tableName: "birds.eagles" },
+  ]);
+});

--- a/src/helpers/multiSchemaHelpers.ts
+++ b/src/helpers/multiSchemaHelpers.ts
@@ -1,0 +1,59 @@
+import {
+  type BlockAttribute,
+  type Model,
+  getSchema,
+} from "@mrleebo/prisma-ast";
+
+type ModelLike = {
+  typeName: string;
+  tableName: string;
+};
+
+/**
+ * Appends schema names to the table names of models.
+ *
+ * Prisma supports multi-schema databases, but currently doens't include the schema name in the DMMT output.
+ * As a workaround, this function parses the schema separately and matches the schema to the model name.
+ *
+ * TODO: Remove this when @prisma/generator-helper exposes schema names in the models by default.
+ *       See thread: https://github.com/prisma/prisma/issues/19987
+ *
+ * @param models list of model names
+ * @param dataModelStr the full datamodel string (schema.prisma contents)
+ * @returns list of models with schema names appended to the table names ("schema.table")
+ */
+export const convertToMultiSchemaModels = <T extends ModelLike>(
+  models: T[],
+  dataModelStr: string
+): T[] => {
+  const parsedSchema = getSchema(dataModelStr);
+
+  const multiSchemaMap = new Map(
+    parsedSchema.list
+      .filter((block): block is Model => block.type === "model")
+      .map((model) => {
+        const schemaProperty = model.properties.find(
+          (prop): prop is BlockAttribute =>
+            prop.type === "attribute" && prop.name === "schema"
+        );
+
+        const schemaName = schemaProperty?.args?.[0].value;
+
+        if (typeof schemaName !== "string") {
+          return [model.name, ""];
+        }
+
+        return [model.name, schemaName.replace(/"/g, "")];
+      })
+  );
+
+  return models.map((model) => {
+    const schemaName = multiSchemaMap.get(model.typeName);
+
+    if (!schemaName) {
+      return model;
+    }
+
+    return { ...model, tableName: `${schemaName}.${model.tableName}` };
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2973,7 +2973,7 @@ lodash.union@^4.6.0:
   resolved "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz"
   integrity sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==
 
-lodash@4.17.21, lodash@^4.17.21:
+lodash@4.17.21, lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,6 +333,33 @@
     human-id "^1.0.2"
     prettier "^2.7.1"
 
+"@chevrotain/cst-dts-gen@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz#922ebd8cc59d97241bb01b1b17561a5c1ae0124e"
+  integrity sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==
+  dependencies:
+    "@chevrotain/gast" "10.5.0"
+    "@chevrotain/types" "10.5.0"
+    lodash "4.17.21"
+
+"@chevrotain/gast@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@chevrotain/gast/-/gast-10.5.0.tgz#e4e614bc46d17a8892742f38e56cd33f1f3ad162"
+  integrity sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==
+  dependencies:
+    "@chevrotain/types" "10.5.0"
+    lodash "4.17.21"
+
+"@chevrotain/types@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@chevrotain/types/-/types-10.5.0.tgz#52a97d74a8cfbc197f054636d93ecd8912d33d21"
+  integrity sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==
+
+"@chevrotain/utils@10.5.0":
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/@chevrotain/utils/-/utils-10.5.0.tgz#0ee36f65b49b447fbac71b9e5af5c5c6c98ac057"
+  integrity sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==
+
 "@esbuild/android-arm64@0.17.14":
   version "0.17.14"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.14.tgz#4624cea3c8941c91f9e9c1228f550d23f1cef037"
@@ -541,6 +568,13 @@
     globby "^11.0.0"
     read-yaml-file "^1.1.0"
 
+"@mrleebo/prisma-ast@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@mrleebo/prisma-ast/-/prisma-ast-0.6.0.tgz#da9837ad111d65e0f823d46fac369a30b1c96913"
+  integrity sha512-hJ7URR8HQ+32IKUWJeYJai6cBGi6AIt6bJjp/5+A+qahLkMh0SS29m9DkBCSkFnA55hI6dHg1sLLeTKEIrH/mw==
+  dependencies:
+    chevrotain "^10.5.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -567,34 +601,34 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.4.1.tgz#ff22eb2e5d476fbc2450a196e40dd243cc20c28f"
   integrity sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==
 
-"@opentelemetry/core@1.12.0":
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.12.0.tgz#afa32341b794045c54c979d4561de2f8f00d0da9"
-  integrity sha512-4DWYNb3dLs2mSCGl65jY3aEgbvPWSHVQV/dmDWiYeWUrMakZQFcymqZOSUNZO0uDrEJoxMu8O5tZktX6UKFwag==
+"@opentelemetry/core@1.14.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.14.0.tgz#64e876b29cb736c984d54164cd47433f513eafd3"
+  integrity sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==
   dependencies:
-    "@opentelemetry/semantic-conventions" "1.12.0"
+    "@opentelemetry/semantic-conventions" "1.14.0"
 
-"@opentelemetry/resources@1.12.0":
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-1.12.0.tgz#895394c727dc3e7e51d1d2cc50907ec07a626dca"
-  integrity sha512-gunMKXG0hJrR0LXrqh7BVbziA/+iJBL3ZbXCXO64uY+SrExkwoyJkpiq9l5ismkGF/A20mDEV7tGwh+KyPw00Q==
+"@opentelemetry/resources@1.14.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-1.14.0.tgz#d6b0a4e71c2706d33c8c6ec7a7b8fea6ad27ddea"
+  integrity sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==
   dependencies:
-    "@opentelemetry/core" "1.12.0"
-    "@opentelemetry/semantic-conventions" "1.12.0"
+    "@opentelemetry/core" "1.14.0"
+    "@opentelemetry/semantic-conventions" "1.14.0"
 
 "@opentelemetry/sdk-trace-base@^1.8.0":
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.12.0.tgz#62b895dbb5900048a85e4899c38fec5585447d4b"
-  integrity sha512-pfCOB3tNDlYVoWuz4D7Ji+Jmy9MHnATWHVpkERdCEiwUGEZ+4IvNPXUcPc37wJVmMpjGLeaWgPPrie0KIpWf1A==
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz#831af08f002228a11e577ff860eb6059c8b80fb7"
+  integrity sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==
   dependencies:
-    "@opentelemetry/core" "1.12.0"
-    "@opentelemetry/resources" "1.12.0"
-    "@opentelemetry/semantic-conventions" "1.12.0"
+    "@opentelemetry/core" "1.14.0"
+    "@opentelemetry/resources" "1.14.0"
+    "@opentelemetry/semantic-conventions" "1.14.0"
 
-"@opentelemetry/semantic-conventions@1.12.0":
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.12.0.tgz#19c959bdb900986e74939d4227e757aa16936b91"
-  integrity sha512-hO+bdeGOlJwqowUBoZF5LyP3ORUFOP1G0GRv8N45W/cztXbT2ZEXaAzfokRS9Xc9FWmYrDj32mF6SzH6wuoIyA==
+"@opentelemetry/semantic-conventions@1.14.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz#6a729b7f372ce30f77a3f217c09bc216f863fccb"
+  integrity sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==
 
 "@prisma/debug@4.13.0":
   version "4.13.0"
@@ -1372,6 +1406,18 @@ checkpoint-client@1.1.23:
     node-fetch "2.6.7"
     uuid "8.3.2"
 
+chevrotain@^10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/chevrotain/-/chevrotain-10.5.0.tgz#9c1dc62ef0753bb562dbe521b5f72d041bad624e"
+  integrity sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==
+  dependencies:
+    "@chevrotain/cst-dts-gen" "10.5.0"
+    "@chevrotain/gast" "10.5.0"
+    "@chevrotain/types" "10.5.0"
+    "@chevrotain/utils" "10.5.0"
+    lodash "4.17.21"
+    regexp-to-ast "0.5.0"
+
 chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
@@ -1400,9 +1446,9 @@ cli-cursor@^3.1.0:
     restore-cursor "^3.1.0"
 
 cli-spinners@^2.5.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.8.0.tgz#e97a3e2bd00e6d85aa0c13d7f9e3ce236f7787fc"
-  integrity sha512-/eG5sJcvEIwxcdYM86k5tPwn0MUzkX5YY3eImTGpJOZgVe4SdTMY14vQpcxgBzJ0wXwAYrS8E+c3uHeK4JNyzQ==
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.0.tgz#5881d0ad96381e117bbe07ad91f2008fe6ffd8db"
+  integrity sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==
 
 cli-truncate@2.1.0:
   version "2.1.0"
@@ -2906,7 +2952,7 @@ lodash.union@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
   integrity sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==
 
-lodash@^4.17.21:
+lodash@4.17.21, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3689,6 +3735,11 @@ regenerator-runtime@^0.13.11:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
+regexp-to-ast@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz#56c73856bee5e1fef7f73a00f1473452ab712a24"
+  integrity sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==
+
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
@@ -4274,10 +4325,15 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-ts-pattern@4.2.2, ts-pattern@^4.0.1:
+ts-pattern@4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/ts-pattern/-/ts-pattern-4.2.2.tgz#e6fae2aa1ff1a7ff2ce3166f8c329a4f252f78d6"
   integrity sha512-qzJMo2pbkUJWusRH5o8xR+xogn6RmvViyUgwBFTtRENLse470clCGjHDf6haWGZ1AOmk8XkEohUoBW8Uut6Scg==
+
+ts-pattern@^4.0.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ts-pattern/-/ts-pattern-4.3.0.tgz#7a995b39342f1b00d1507c2d2f3b90ea16e178a6"
+  integrity sha512-pefrkcd4lmIVR0LA49Imjf9DYLK8vtWhqBPA3Ya1ir8xCW0O2yjL9dsCVvI7pCodLC5q7smNpEtDR2yVulQxOg==
 
 tsconfck@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
## Context

Prisma supports multi-schemas via the `multiSchema` preview feature (https://www.prisma.io/docs/guides/other/multi-schema), but the schemas are not appended to the table names generated by `prisma-kysely`.

Sadly, `@prisma/generator-helper` doesn't expose the model schemas set via `@@schema("schemaName")`, so a workaround is needed for now. I've opened an issue for Prisma to fix this here: https://github.com/prisma/prisma/issues/19987

## Changes

- Add support for `multiSchema` and `@@schema()` attributes.
  - Uses `@@mrleebo/prisma-ast` to parse the datamodel separately and matches the schemas with the correct model. This is a workaround and is only needed until Prisma exposes the schema attribute on the `DMMF.Model` objects themselves.
  - Appends the schema name to the table names on the `DB` type (like what `kysely-codegen` does)
  - Does nothing if `multiSchema` is not enabled.
- Sort DB properties by table name instead of type name.
  - Especially noticeable when using multi-schemas, but makes sense without it too.
- Add changesets reflecting the changes.

## Alternative solutions

- If you want to avoid third-party libs like `@@mrleebo/prisma-ast` then we could do it via bracket matching instead, though it's a bit more complex and potentially error prone.
- Wait for Prisma to expose the schema themselves, although that might take time.

## Example output

<details>
<summary>Toggle example</summary>

**`prisma.schema` (partial)**

```prisma
model Elephant {
  id   Int    @id
  name String

  @@map("elephants")
  @@schema("mammals")
}

model Eagle {
  id   Int    @id
  name String

  @@map("eagles")
  @@schema("birds")
}
```

**Generated DB type before PR:**

```ts
export type DB = {
  eagles: Eagle;
  elephants: Elephant;
};
```


**Generated DB type after PR:**

```ts
export type DB = {
  "birds.eagles": Eagle;
  "mammals.elephants": Elephant;
};
```

</details>