### PR TITLE
Fixed Empty Output Issue and Run without installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,7 @@ without losing the safety of the TypeScript type system?
 
 ### Setup
 
-1. Install `prisma-kysely` using your package manager of choice:
-
-   ```sh
-   yarn add prisma-kysely
-   ```
-
-2. Replace (or augment) the default client generator in your `schema.prisma`
+1. Replace (or augment) the default client generator in your `schema.prisma`
    file with the following:
 
    ```prisma
@@ -39,11 +33,11 @@ without losing the safety of the TypeScript type system?
        output = "../src/db"
        fileName = "types.ts"
        // Optionally generate runtime enums to a separate file
-        enumFileName = "enums.ts"
+       enumFileName = "enums.ts"
    }
    ```
 
-3. Run `prisma migrate dev` or `prisma generate` and use your freshly generated
+2. Run `prisma migrate dev` or `prisma generate` and use your freshly generated
    types when instantiating Kysely!
 
 ### Motivation

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ without losing the safety of the TypeScript type system?
 
    ```prisma
    generator kysely {
-       provider = "prisma-kysely"
+       provider = "npx prisma-kysely"
 
        // Optionally provide a destination directory for the generated file
        // and a filename of your choice
@@ -154,11 +154,13 @@ Here's everything you need to do (let me know if something's missing...)
 3. Make changes to the source code
 4. Test your changes by creating `prisma/schema.prisma`, running `yarn prisma generate` and checking the output in `prisma/types.ts`. The provider must be set
    as follows to reference the dev build:
+
    ```prisma
    generator kysely {
        provider = "node ./dist/bin.js"
    }
    ```
+
 5. Create a pull request! If your changes make sense, I'll try my best to review
    and merge them quickly.
 


### PR DESCRIPTION
So, I have been facing an issue where the generator does not generate anything. It even creates the `generated` directory but there is no file.

So, I have tested some solutions and found out that, it requires you to have prisma-kysely installed globally, with `npm install -g prisma-kysely` as it executes the command `prisma-kysely`. So, if you do not have it installed globally this does nothing.
But this can be easily solvable by using npx as npx helps to run the prisma-kysely script without having installed it globally.

And this also minimizes the need of installing the script altogether.

