### PR TITLE
fix: correctly generate array types with defaults in prisma schema

### DIFF
--- a/.changeset/fluffy-monkeys-play.md
+++ b/.changeset/fluffy-monkeys-play.md
@@ -1,0 +1,5 @@
+---
+"prisma-kysely": patch
+---
+
+Fixes array types (Thanks Karrui! 🥳🇸🇬)

--- a/src/helpers/generateField.test.ts
+++ b/src/helpers/generateField.test.ts
@@ -77,6 +77,23 @@ test("it creates correct annotation for list types", () => {
   expect(result).toEqual("name: string[];");
 });
 
+test("it creates correct annotation for generated list types", () => {
+  const node = generateField({
+    name: "name",
+    type: stringTypeNode,
+    nullable: false,
+    generated: true,
+    list: true,
+    isId: false,
+    config: {
+      readOnlyIds: false,
+    },
+  });
+  const result = stringifyTsNode(node);
+
+  expect(result).toEqual("name: Generated<string[]>;");
+});
+
 test("it creates correct annotation for generated nullable list types (do these exist?)", () => {
   // Is this how these work? I have no clue. I don't even know if Kysely supports these.
   // If you run into problems here, please file an issue or create a pull request.
@@ -94,7 +111,7 @@ test("it creates correct annotation for generated nullable list types (do these 
   });
   const result = stringifyTsNode(node);
 
-  expect(result).toEqual("name: Generated<string | null>[];");
+  expect(result).toEqual("name: Generated<(string | null)[]>;");
 });
 
 test("it prepends a JSDoc comment if documentation is provided", () => {

--- a/src/helpers/generateField.ts
+++ b/src/helpers/generateField.ts
@@ -37,6 +37,8 @@ export const generateField = (args: GenerateFieldArgs) => {
       ),
     ]);
 
+  if (list) fieldType = ts.factory.createArrayTypeNode(fieldType);
+
   if (generated) {
     if (isId && config.readOnlyIds) {
       fieldType = ts.factory.createTypeReferenceNode(
@@ -50,8 +52,6 @@ export const generateField = (args: GenerateFieldArgs) => {
       );
     }
   }
-
-  if (list) fieldType = ts.factory.createArrayTypeNode(fieldType);
 
   const nameIdentifier = isValidTSIdentifier(name)
     ? ts.factory.createIdentifier(name)


### PR DESCRIPTION
Closes https://github.com/valtyr/prisma-kysely/issues/62


## Why this change?
Currently, if a column is an array type with a default array set, the generated output type `Generated<T>[]` is invalid and unusable with the `Insertable` and `Selectable` types (example below)


`Generated<T>[]` as a type cannot be unwrapped by `Insertable`, and thus type errors gets triggered when trying to insert the affected array props.

## Example
```prisma
model Activity {
  id String @id @default(dbgenerated("gen_random_uuid()"))
  name        String
  aliases     String[] @default([])
  description String?
}
```

## Old output
```ts
export type Activity = {
  id: Generated<string>;
  name: string;
  aliases: Generated<string>[];
  description: string | null;
};
```

## New output
```ts
export type Activity = {
  id: Generated<string>;
  name: string;
  aliases: Generated<string[]>;
  description: string | null;
};
```

## Notes
Note that the test for nullable generated types has changed, but I also think that it changes to the correct check.
