### PR TITLE
Handle enum primary keys on many-to-many relationships

### DIFF
--- a/.changeset/sweet-poets-swim.md
+++ b/.changeset/sweet-poets-swim.md
@@ -1,0 +1,5 @@
+---
+"prisma-kysely": patch
+---
+
+Handle enum primary keys on many-to-many relationships

--- a/src/helpers/generateImplicitManyToManyModels.test.ts
+++ b/src/helpers/generateImplicitManyToManyModels.test.ts
@@ -512,3 +512,118 @@ test("it generates correct field types when a field name is defferent from model
     },
   ]);
 });
+
+test("it generates correct field kinds when an enum is used", () => {
+  const newModels = generateImplicitManyToManyModels([
+    {
+      name: "UserRole",
+      fields: [
+        {
+          name: "roleId",
+          kind: "enum",
+          isList: false,
+          isRequired: true,
+          isUnique: false,
+          isId: true,
+          isReadOnly: false,
+          hasDefaultValue: false,
+          type: "UserRoleType",
+          isGenerated: false,
+          isUpdatedAt: false,
+        },
+        {
+          name: "permissions",
+          kind: "object",
+          isList: true,
+          isRequired: true,
+          isUnique: false,
+          isId: false,
+          isReadOnly: false,
+          hasDefaultValue: false,
+          type: "Permission",
+          relationName: "PermissionToUserRole",
+          relationFromFields: [],
+          relationToFields: [],
+          isGenerated: false,
+          isUpdatedAt: false,
+        },
+      ],
+      primaryKey: null,
+      dbName: null,
+      uniqueFields: [],
+      uniqueIndexes: [],
+    },
+    {
+      name: "Permission",
+      fields: [
+        {
+          name: "permissionId",
+          kind: "scalar",
+          isList: false,
+          isRequired: true,
+          isUnique: false,
+          isId: true,
+          isReadOnly: false,
+          hasDefaultValue: false,
+          type: "String",
+          isGenerated: false,
+          isUpdatedAt: false,
+        },
+        {
+          name: "roles",
+          kind: "object",
+          isList: true,
+          isRequired: true,
+          isUnique: false,
+          isId: false,
+          isReadOnly: false,
+          hasDefaultValue: false,
+          type: "UserRole",
+          relationName: "PermissionToUserRole",
+          relationFromFields: [],
+          relationToFields: [],
+          isGenerated: false,
+          isUpdatedAt: false,
+        },
+      ],
+      primaryKey: null,
+      dbName: null,
+      uniqueFields: [],
+      uniqueIndexes: [],
+    },
+  ]);
+
+  expect(newModels).toEqual<DMMF.Model[]>([
+    {
+      dbName: "_PermissionToUserRole",
+      name: "PermissionToUserRole",
+      primaryKey: null,
+      uniqueFields: [],
+      uniqueIndexes: [],
+      fields: [
+        {
+          name: "A",
+          type: "String",
+          kind: "scalar",
+          isRequired: true,
+          isList: false,
+          isUnique: false,
+          isId: false,
+          isReadOnly: true,
+          hasDefaultValue: false,
+        },
+        {
+          name: "B",
+          type: "UserRoleType",
+          kind: "enum",
+          isRequired: true,
+          isList: false,
+          isUnique: false,
+          isId: false,
+          isReadOnly: true,
+          hasDefaultValue: false,
+        },
+      ],
+    },
+  ]);
+});

--- a/src/helpers/generateImplicitManyToManyModels.ts
+++ b/src/helpers/generateImplicitManyToManyModels.ts
@@ -72,14 +72,14 @@ function generateJoinFields(
   if (fields.length !== 2) throw new Error("Huh?");
 
   const sortedFields = sorted(fields, (a, b) => a.type.localeCompare(b.type));
-  const A = sortedFields[0];
-  const B = sortedFields[1];
+  const joinedA = getJoinIdField(sortedFields[0], models);
+  const joinedB = getJoinIdField(sortedFields[1], models);
 
   return [
     {
       name: "A",
-      type: getJoinIdType(A, models),
-      kind: "scalar",
+      type: joinedA.type,
+      kind: joinedA.kind,
       isRequired: true,
       isList: false,
       isUnique: false,
@@ -89,8 +89,8 @@ function generateJoinFields(
     },
     {
       name: "B",
-      type: getJoinIdType(B, models),
-      kind: "scalar",
+      type: joinedB.type,
+      kind: joinedB.kind,
       isRequired: true,
       isList: false,
       isUnique: false,
@@ -101,14 +101,17 @@ function generateJoinFields(
   ];
 }
 
-function getJoinIdType(joinField: DMMF.Field, models: DMMF.Model[]): string {
+function getJoinIdField(
+  joinField: DMMF.Field,
+  models: DMMF.Model[]
+): DMMF.Field {
   const joinedModel = models.find((m) => m.name === joinField.type);
   if (!joinedModel) throw new Error("Could not find referenced model");
 
   const idField = joinedModel.fields.find((f) => f.isId);
   if (!idField) throw new Error("No ID field on referenced model");
 
-  return idField.type;
+  return idField;
 }
 
 function filterManyToManyRelationFields(models: DMMF.Model[]) {


### PR DESCRIPTION
This PR aims to fix an error that occurs when enums are used as part of implicit many-to-many relations.

### Reproducing
```prisma
enum RoleType {
  User
  Admin
}

model Role {
  roleId      RoleType     @id
  permissions Permission[]
}

model Permission {
  permissionId String @id
  roles        Role[]
}
```

```bash
yarn prisma generate
```

### Cause
The generator for many-to-many implicit relationships presumes the fields involved in these relations are scalars, but they can also be enums too. The pre-supposition that the field is a scalar means that enums are not considered, and when converting from a Prisma type to a database type in `generateFieldType`, it is unable to find a mapping between the two.

```
Error:
Unsupported type RoleType for database postgresql
```

### Fix
The provided fix augments the existing function `getJoinIdType` to look-up the corresponding field and uses both the `type` and the `kind` in the generated join fields.
