### PR TITLE
List enum values should be typed as strings

### DIFF
--- a/.changeset/angry-rivers-fail.md
+++ b/.changeset/angry-rivers-fail.md
@@ -1,0 +1,5 @@
+---
+"prisma-kysely": minor
+---
+
+Make enum array values actually be strings

--- a/package.json
+++ b/package.json
@@ -63,5 +63,6 @@
     ],
     "importOrderSeparation": true,
     "importOrderSortSpecifiers": true
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }

--- a/src/__test__/e2e.test.ts
+++ b/src/__test__/e2e.test.ts
@@ -156,7 +156,7 @@ test(
         C
     }
     
-    model TestUser {  
+    model TestUser {
         id          String @id
         name        String
         age         Int
@@ -173,8 +173,6 @@ test(
     const typeFile = await fs.readFile("./prisma/generated/types.ts", {
       encoding: "utf-8",
     });
-
-    console.log(typeFile);
 
     expect(typeFile).not.toContain("export const");
     expect(typeFile).toContain(`import type { TestEnum } from "./enums";`);

--- a/src/helpers/generateFile.ts
+++ b/src/helpers/generateFile.ts
@@ -25,7 +25,9 @@ export const generateFile = (
 export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
   ? ColumnType<S, I | undefined, U>
   : ColumnType<T, T | undefined, T>;
-export type Timestamp = ColumnType<Date, Date | string, Date | string>;`;
+export type Timestamp = ColumnType<Date, Date | string, Date | string>;
+export type EnumArrayInner<T extends string, All extends string> = T extends infer Single extends string ? T | \`\${Single},\${Exclude<All, Single>}\` : never
+export type EnumArray<T extends string> = \`{\${EnumArrayInner<T, T>}}\`;`;
 
   if (withEnumImport) {
     const enumImportStatement = `import type { ${withEnumImport.names.join(

--- a/src/helpers/generateFile.ts
+++ b/src/helpers/generateFile.ts
@@ -27,7 +27,7 @@ export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
   : ColumnType<T, T | undefined, T>;
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 export type EnumArrayInner<T extends string, All extends string> = T extends infer Single extends string ? T | \`\${Single},\${Exclude<All, Single>}\` : never
-export type EnumArray<T extends string> = \`{\${EnumArrayInner<T, T>}}\`;`;
+export type EnumArray<T extends string> = '{}' | \`{\${EnumArrayInner<T, T>}}\`;`;
 
   if (withEnumImport) {
     const enumImportStatement = `import type { ${withEnumImport.names.join(

--- a/src/helpers/generateModel.test.ts
+++ b/src/helpers/generateModel.test.ts
@@ -165,3 +165,42 @@ test("it respects camelCase option", () => {
     userName: string | null;
 };`);
 });
+
+test("it respects enum array values", () => {
+  const model = generateModel(
+    {
+      name: "User",
+      fields: [
+        {
+          name: "permissions",
+          isId: false,
+          isGenerated: false,
+          kind: "enum",
+          type: "UserPermissions",
+          hasDefaultValue: true,
+          isList: true,
+          isReadOnly: false,
+          isRequired: true,
+          isUnique: false,
+        },
+      ],
+      primaryKey: null,
+      uniqueFields: [],
+      uniqueIndexes: [],
+      dbName: null,
+    },
+    {
+      databaseProvider: "postgresql",
+      fileName: "env(DATABASE_URL)",
+      enumFileName: "",
+      camelCase: true,
+      readOnlyIds: false,
+    }
+  );
+
+  const source = stringifyTsNode(model.definition);
+
+  expect(source).toEqual(`export type User = {
+    permissions: EnumArray<UserPermissions>;
+};`);
+});

--- a/src/helpers/generateModel.test.ts
+++ b/src/helpers/generateModel.test.ts
@@ -177,7 +177,7 @@ test("it respects enum array values", () => {
           isGenerated: false,
           kind: "enum",
           type: "UserPermissions",
-          hasDefaultValue: true,
+          hasDefaultValue: false,
           isList: true,
           isReadOnly: false,
           isRequired: true,

--- a/src/helpers/generateModel.ts
+++ b/src/helpers/generateModel.ts
@@ -33,23 +33,27 @@ export const generateModel = (model: DMMF.Model, config: Config) => {
     const dbName = typeof field.dbName === "string" ? field.dbName : null;
 
     if (field.kind === "enum") {
+      console.log(field);
+
+      const type = field.isList
+        ? ts.factory.createTypeReferenceNode(
+            ts.factory.createIdentifier("EnumArray"),
+            [
+              ts.factory.createTypeReferenceNode(
+                ts.factory.createIdentifier(field.type),
+                undefined
+              ),
+            ]
+          )
+        : ts.factory.createTypeReferenceNode(
+            ts.factory.createIdentifier(field.type),
+            undefined
+          );
+
       return generateField({
         isId: field.isId,
         name: normalizeCase(dbName || field.name, config),
-        type: field.isList
-          ? ts.factory.createTypeReferenceNode(
-              ts.factory.createIdentifier("EnumArray"),
-              [
-                ts.factory.createTypeReferenceNode(
-                  ts.factory.createIdentifier(field.type),
-                  undefined
-                ),
-              ]
-            )
-          : ts.factory.createTypeReferenceNode(
-              ts.factory.createIdentifier(field.type),
-              undefined
-            ),
+        type,
         nullable: !field.isRequired,
         generated: isGenerated,
         // Enum list values are handled as strings, so we don't need to wrap them in a list

--- a/src/helpers/generateModel.ts
+++ b/src/helpers/generateModel.ts
@@ -52,7 +52,8 @@ export const generateModel = (model: DMMF.Model, config: Config) => {
             ),
         nullable: !field.isRequired,
         generated: isGenerated,
-        list: field.isList,
+        // Enum list values are handled as strings, so we don't need to wrap them in a list
+        list: false,
         documentation: field.documentation,
         config,
       });

--- a/src/helpers/generateModel.ts
+++ b/src/helpers/generateModel.ts
@@ -36,10 +36,20 @@ export const generateModel = (model: DMMF.Model, config: Config) => {
       return generateField({
         isId: field.isId,
         name: normalizeCase(dbName || field.name, config),
-        type: ts.factory.createTypeReferenceNode(
-          ts.factory.createIdentifier(field.type),
-          undefined
-        ),
+        type: field.isList
+          ? ts.factory.createTypeReferenceNode(
+              ts.factory.createIdentifier("EnumArray"),
+              [
+                ts.factory.createTypeReferenceNode(
+                  ts.factory.createIdentifier(field.type),
+                  undefined
+                ),
+              ]
+            )
+          : ts.factory.createTypeReferenceNode(
+              ts.factory.createIdentifier(field.type),
+              undefined
+            ),
         nullable: !field.isRequired,
         generated: isGenerated,
         list: field.isList,

--- a/src/helpers/generateModel.ts
+++ b/src/helpers/generateModel.ts
@@ -33,8 +33,6 @@ export const generateModel = (model: DMMF.Model, config: Config) => {
     const dbName = typeof field.dbName === "string" ? field.dbName : null;
 
     if (field.kind === "enum") {
-      console.log(field);
-
       const type = field.isList
         ? ts.factory.createTypeReferenceNode(
             ts.factory.createIdentifier("EnumArray"),


### PR DESCRIPTION
This PR introduces a fix where enum list values are typed as `MyEnum[]` but Prisma's migrations actually store them as a string format.

Since kysely is just a query builder, we couldn't expect it to parse this string format into an array, so I think it makes the most sense to have it typed like this.

If you would like to merge this, please could I ask you throughly check the PR, it's very possible I've missed something as I only spent a few minutes looking around the codebase for supporting this feature.

Thanks for prisma-kysely, it's a wonderful tool!

fixes #107