### PR TITLE
Generate enum cast helper for Postgres

### DIFF
--- a/src/helpers/generateEnumCastHelper.test.ts
+++ b/src/helpers/generateEnumCastHelper.test.ts
@@ -1,0 +1,69 @@
+import ts, { createPrinter } from "typescript";
+import { expect, test } from "vitest";
+
+import { generateEnumCastHelper } from "~/helpers/generateEnumCastHelper";
+
+test("it generates nothing if there are no enums", () => {
+  const result = generateEnumCastHelper([]);
+  expect(result).toEqual([]);
+});
+
+test("it generates the enum cast helper", () => {
+  const multiSchemaMap = new Map([["TemperatureUnit", "units"]]);
+
+  const [
+    namesObjectDeclaration,
+    namesTypeDeclaration,
+    valuesTypeDeclaration,
+    castFunctionDeclaration,
+  ] = generateEnumCastHelper(
+    [
+      {
+        name: "Foo",
+        values: [
+          { name: "Foo", dbName: null },
+          { name: "Bar", dbName: null },
+        ],
+      },
+      {
+        name: "Shape",
+        dbName: "a shape",
+        values: [
+          { name: "CIRCLE", dbName: null },
+          { name: "SQUARE", dbName: null },
+        ],
+      },
+      {
+        name: "TemperatureUnit",
+        dbName: "temperature_unit",
+        values: [
+          { name: "CELSIUS", dbName: null },
+          { name: "FAHRENHEIT", dbName: null },
+        ],
+      },
+    ],
+    multiSchemaMap
+  );
+
+  const printer = createPrinter();
+
+  const result = printer.printList(
+    ts.ListFormat.MultiLine,
+    ts.factory.createNodeArray([
+      namesObjectDeclaration,
+      namesTypeDeclaration,
+      valuesTypeDeclaration,
+      castFunctionDeclaration,
+    ]),
+    ts.createSourceFile("", "", ts.ScriptTarget.Latest)
+  );
+
+  expect(result).toEqual(`const EnumNames = {
+    Foo: Foo,
+    "a shape": Shape,
+    "units.temperature_unit": TemperatureUnit
+} as const;
+type EnumNames = typeof EnumNames;
+type EnumValues<Name extends keyof EnumNames> = EnumNames[Name][keyof EnumNames[Name]];
+export function castEnumValue<Name extends keyof EnumNames, Value extends EnumValues<Name> | null>(value: Value | ExpressionWrapper<any, any, Value>, name: Name): RawBuilder<Value> { return sql<Value> \`\${value}::\${sql.id(name)}\`; }\n`);
+});

--- a/src/helpers/generateEnumCastHelper.ts
+++ b/src/helpers/generateEnumCastHelper.ts
@@ -1,0 +1,171 @@
+import type { DMMF } from "@prisma/generator-helper";
+import type { Identifier } from "typescript";
+import ts from "typescript";
+
+import isValidTSIdentifier from "~/utils/isValidTSIdentifier";
+
+export const generateEnumCastHelper = (
+  enums: DMMF.DatamodelEnum[],
+  multiSchemaMap?: Map<string, string>
+) => {
+  if (!enums.length) return [];
+
+  const namesObjectDeclaration = ts.factory.createVariableStatement(
+    [],
+    ts.factory.createVariableDeclarationList(
+      [
+        ts.factory.createVariableDeclaration(
+          "EnumNames",
+          undefined,
+          undefined,
+          ts.factory.createAsExpression(
+            ts.factory.createObjectLiteralExpression(
+              enums.map((e) => {
+                const schemaName = multiSchemaMap?.get(e.name);
+                // dbName holds the "@@map("name")" value from the Prisma schema if it exists, otherwise fall back to the name
+                const dbName = e.dbName || e.name;
+                // Prepend the schema name if we have one
+                const dbNameWithSchema = schemaName
+                  ? `${schemaName}.${dbName}`
+                  : dbName;
+                const identifier = isValidTSIdentifier(dbNameWithSchema)
+                  ? ts.factory.createIdentifier(dbNameWithSchema)
+                  : ts.factory.createStringLiteral(dbNameWithSchema);
+
+                return ts.factory.createPropertyAssignment(
+                  identifier,
+                  ts.factory.createIdentifier(e.name)
+                );
+              }),
+              true
+            ),
+            ts.factory.createTypeReferenceNode(
+              ts.factory.createIdentifier("const"),
+              undefined
+            )
+          )
+        ),
+      ],
+      ts.NodeFlags.Const
+    )
+  );
+
+  const namesTypeDeclaration = ts.factory.createTypeAliasDeclaration(
+    [],
+    "EnumNames",
+    [],
+    ts.factory.createTypeQueryNode(
+      namesObjectDeclaration.declarationList.declarations[0].name as Identifier
+    )
+  );
+  const nameTypeParameterDeclaration =
+    ts.factory.createTypeParameterDeclaration(
+      [],
+      "Name",
+      ts.factory.createTypeOperatorNode(
+        ts.SyntaxKind.KeyOfKeyword,
+        ts.factory.createTypeReferenceNode(namesTypeDeclaration.name)
+      )
+    );
+  const indexedNameAccessType = ts.factory.createIndexedAccessTypeNode(
+    ts.factory.createTypeReferenceNode(namesTypeDeclaration.name),
+    ts.factory.createTypeReferenceNode(nameTypeParameterDeclaration.name)
+  );
+
+  const valuesTypeDeclaration = ts.factory.createTypeAliasDeclaration(
+    [],
+    "EnumValues",
+    [nameTypeParameterDeclaration],
+    ts.factory.createIndexedAccessTypeNode(
+      indexedNameAccessType,
+      ts.factory.createTypeOperatorNode(
+        ts.SyntaxKind.KeyOfKeyword,
+        indexedNameAccessType
+      )
+    )
+  );
+
+  const valueTypeParameterDeclaration =
+    ts.factory.createTypeParameterDeclaration(
+      [],
+      "Value",
+      ts.factory.createUnionTypeNode([
+        ts.factory.createTypeReferenceNode(valuesTypeDeclaration.name, [
+          ts.factory.createTypeReferenceNode(nameTypeParameterDeclaration.name),
+        ]),
+        ts.factory.createLiteralTypeNode(ts.factory.createNull()),
+      ])
+    );
+
+  const nameParameterDeclaration = ts.factory.createParameterDeclaration(
+    [],
+    undefined,
+    "name",
+    undefined,
+    ts.factory.createTypeReferenceNode(nameTypeParameterDeclaration.name)
+  );
+  const valueParameterDeclaration = ts.factory.createParameterDeclaration(
+    [],
+    undefined,
+    "value",
+    undefined,
+    ts.factory.createUnionTypeNode([
+      ts.factory.createTypeReferenceNode(valueTypeParameterDeclaration.name),
+      ts.factory.createTypeReferenceNode("ExpressionWrapper", [
+        ts.factory.createTypeReferenceNode("any"),
+        ts.factory.createTypeReferenceNode("any"),
+        ts.factory.createTypeReferenceNode(valueTypeParameterDeclaration.name),
+      ]),
+    ])
+  );
+
+  const castEnumValueFunctionDeclaration = ts.factory.createFunctionDeclaration(
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    undefined,
+    "castEnumValue",
+    [nameTypeParameterDeclaration, valueTypeParameterDeclaration],
+    [valueParameterDeclaration, nameParameterDeclaration],
+    ts.factory.createTypeReferenceNode("RawBuilder", [
+      ts.factory.createTypeReferenceNode(valueTypeParameterDeclaration.name),
+    ]),
+    ts.factory.createBlock([
+      ts.factory.createReturnStatement(
+        ts.factory.createTaggedTemplateExpression(
+          ts.factory.createIdentifier("sql"),
+          [
+            ts.factory.createTypeReferenceNode(
+              valueTypeParameterDeclaration.name
+            ),
+          ],
+          ts.factory.createTemplateExpression(
+            ts.factory.createTemplateHead(""),
+            [
+              ts.factory.createTemplateSpan(
+                valueParameterDeclaration.name as Identifier,
+                ts.factory.createTemplateMiddle("::")
+              ),
+              ts.factory.createTemplateSpan(
+                ts.factory.createCallExpression(
+                  ts.factory.createPropertyAccessExpression(
+                    ts.factory.createIdentifier("sql"),
+                    ts.factory.createIdentifier("id")
+                  ),
+                  undefined,
+                  [nameParameterDeclaration.name as Identifier]
+                ),
+                ts.factory.createTemplateTail("")
+              ),
+            ]
+          )
+        )
+      ),
+    ])
+  );
+
+  return [
+    namesObjectDeclaration,
+    namesTypeDeclaration,
+    valuesTypeDeclaration,
+    castEnumValueFunctionDeclaration,
+  ];
+};

--- a/src/helpers/generateFile.ts
+++ b/src/helpers/generateFile.ts
@@ -19,9 +19,11 @@ export const generateFile = (
 
   const result = printer.printFile(file);
 
-  const leader = `import type { ColumnType${
-    result.includes("GeneratedAlways") ? ", GeneratedAlways" : ""
-  } } from "kysely";
+  const leader = `import { ColumnType${
+    result.includes("ExpressionWrapper") ? ", ExpressionWrapper" : ""
+  }${result.includes("GeneratedAlways") ? ", GeneratedAlways" : ""}${
+    result.includes("RawBuilder") ? ", RawBuilder" : ""
+  }${result.includes("sql") ? ", sql" : ""} } from "kysely";
 export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
   ? ColumnType<S, I | undefined, U>
   : ColumnType<T, T | undefined, T>;

--- a/src/helpers/generateFiles.ts
+++ b/src/helpers/generateFiles.ts
@@ -1,5 +1,9 @@
 import path from "path";
-import type { TypeAliasDeclaration, VariableStatement } from "typescript";
+import type {
+  FunctionDeclaration,
+  TypeAliasDeclaration,
+  VariableStatement,
+} from "typescript";
 
 import { generateFile } from "~/helpers/generateFile";
 
@@ -8,6 +12,11 @@ type File = { filepath: string; content: ReturnType<typeof generateFile> };
 export function generateFiles(opts: {
   typesOutfile: string;
   enums: (VariableStatement | TypeAliasDeclaration)[];
+  enumCastHelper: (
+    | VariableStatement
+    | TypeAliasDeclaration
+    | FunctionDeclaration
+  )[];
   enumNames: string[];
   enumsOutfile: string;
   databaseType: TypeAliasDeclaration;
@@ -18,7 +27,12 @@ export function generateFiles(opts: {
     const typesFileWithEnums: File = {
       filepath: opts.typesOutfile,
       content: generateFile(
-        [...opts.enums, ...opts.modelDefinitions, opts.databaseType],
+        [
+          ...opts.enums,
+          ...opts.enumCastHelper,
+          ...opts.modelDefinitions,
+          opts.databaseType,
+        ],
         {
           withEnumImport: false,
           withLeader: true,
@@ -44,9 +58,9 @@ export function generateFiles(opts: {
 
   const enumFile: File = {
     filepath: opts.enumsOutfile,
-    content: generateFile(opts.enums, {
+    content: generateFile([...opts.enums, ...opts.enumCastHelper], {
       withEnumImport: false,
-      withLeader: false,
+      withLeader: true,
     }),
   };
 

--- a/src/helpers/multiSchemaHelpers.test.ts
+++ b/src/helpers/multiSchemaHelpers.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "vitest";
 
-import { convertToMultiSchemaModels } from "./multiSchemaHelpers";
+import {
+  buildMultiSchemaMap,
+  convertToMultiSchemaModels,
+} from "./multiSchemaHelpers";
 
 const testDataModel = `generator kysely {
   provider        = "node ./dist/bin.js"
@@ -27,7 +30,25 @@ model Eagle {
 
   @@map("eagles")
   @@schema("birds")
+}
+
+enum BirdKind {
+  EAGLE
+
+  @@schema("birds")
 }`;
+
+test("builds a map of schema names to object names", () => {
+  const result = buildMultiSchemaMap(testDataModel);
+
+  expect(result).toEqual(
+    new Map([
+      ["Elephant", "mammals"],
+      ["Eagle", "birds"],
+      ["BirdKind", "birds"],
+    ])
+  );
+});
 
 test("returns a list of models with schemas appended to the table name", () => {
   const initialModels = [
@@ -35,7 +56,8 @@ test("returns a list of models with schemas appended to the table name", () => {
     { typeName: "Eagle", tableName: "eagles" },
   ];
 
-  const result = convertToMultiSchemaModels(initialModels, testDataModel);
+  const multiSchemaMap = buildMultiSchemaMap(testDataModel);
+  const result = convertToMultiSchemaModels(multiSchemaMap, initialModels);
 
   expect(result).toEqual([
     { typeName: "Elephant", tableName: "mammals.elephants" },


### PR DESCRIPTION
Closes #104. Related: https://github.com/eoin-obrien/prisma-extension-kysely/issues/72, https://github.com/kysely-org/kysely/issues/198.

Hey! This change adds to the generated code a helper function that can be used to type-safely cast enum literals in PostgreSQL queries.

To give an example, a query that before might have looked like this:
```typescript
const unit: TemperatureUnit = "CELSIUS";
kysely.selectFrom("temperatures")
    .where("unit", "=", sql<TemperatureUnit>`${unit}::temperature_unit` /* zero type safety here! */)
    .selectAll()
```

Can be written as follows with this extension:
```typescript
const unit: TemperatureUnit = "CELSIUS";
kysely.selectFrom("temperatures")
    .where("unit", "=", castEnumValue(unit, "temperature_unit" /* type-checked! */))
    .selectAll()
```

The change is compatible with the support for Prisma's `multiSchema` feature introduced in #56.

Curious to hear if this is something you'd consider merging.