### PR TITLE
Harden GitHub Actions against supply-chain attacks

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 permissions:
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,18 +20,18 @@ jobs:
       contents: read
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: .nvmrc
 
       - name: 🏗 Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: 📦 Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: 🧪 Run tests
         run: bun run test
@@ -43,18 +43,18 @@ jobs:
       contents: read
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: .nvmrc
 
       - name: 🏗 Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: 📦 Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: 🤓 Run type checker
         run: bun run typecheck
@@ -67,18 +67,18 @@ jobs:
       contents: read
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: .nvmrc
 
       - name: 🏗 Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: 📦 Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: 👮‍♂️ Run linters
         run: bun run lint
@@ -89,7 +89,7 @@ jobs:
 
       - name: 💬 Post a check explaining the issue
         if: ${{ failure() && steps.diffCheck.conclusion == 'failure' }}
-        uses: LouisBrunner/checks-action@v2
+        uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: 🧹 Check all files are formatted correctly

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -63,7 +63,6 @@ jobs:
     name: 👮‍♂️ Linters and formatters
     runs-on: ubuntu-latest
     permissions:
-      checks: write # Allow creating checks
       contents: read
     steps:
       - name: 🏗 Setup repo
@@ -87,12 +86,13 @@ jobs:
         id: diffCheck
         run: bun run fix && git diff --exit-code -- ':!bun.lock'
 
-      - name: 💬 Post a check explaining the issue
+      - name: 💬 Explain the formatting failure
         if: ${{ failure() && steps.diffCheck.conclusion == 'failure' }}
-        uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: 🧹 Check all files are formatted correctly
-          conclusion: failure
-          output: |
-            {"summary": "Hrm, seems like you don't have prettier set up properly. Make sure your editor is configured to format code automatically, and that it respects the project's prettier config. [Click here](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) to view the Prettier extension for VS Code.\n\n> _**💡 Tip:**_ \n> \n> In the meantime you can run `bun run fix` and commit the changes."}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'SUMMARY'
+          ## 🧹 Some files aren't formatted correctly
+
+          Make sure your editor is configured to format code automatically and respects the project's Prettier config. [Click here](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) to install the Prettier extension for VS Code.
+
+          > **💡 Tip:** In the meantime you can run `bun run fix` and commit the changes.
+          SUMMARY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,6 @@ concurrency:
 
 permissions:
   contents: write
-  issues: write
   pull-requests: write
   id-token: write
 
@@ -21,22 +20,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: .nvmrc
 
       - name: 🏗 Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Dependencies
-        run: bun install
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
           publish: bun run release
         env:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -11,21 +11,24 @@ jobs:
   release:
     name: Publish snapshot release
     runs-on: ubuntu-latest
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/snapshot')
+    if: >
+      github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+      startsWith(github.event.comment.body, '/snapshot')
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: .nvmrc
 
       - name: 🏗 Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build
         run: bun run build

--- a/package.json
+++ b/package.json
@@ -79,5 +79,5 @@
   "peerDependencies": {
     "prisma": ">=7.0.0"
   },
-  "packageManager": "bun@1.3.5"
+  "packageManager": "bun@1.3.14"
 }


### PR DESCRIPTION
Hardens our CI against the supply-chain attack patterns going around (Shai-Hulud worm, the `tj-actions/changed-files` token theft, and the `pull_request_target` + malicious `.claude/settings.json` hook that hit `aidenybai/million` and TanStack).

## Audit results
- ✅ No `pull_request_target` anywhere (the vector that hit Million/TanStack)
- ✅ No malicious `.claude` / editor hook; `.vscode/settings.json` only sets the Prettier formatter
- ✅ No committed `.npmrc` / npm token — we publish via **OIDC provenance** (`id-token: write` + `NPM_CONFIG_PROVENANCE`), so the "npm invalidated all tokens" event doesn't affect us

## Changes
1. **Pin every action to a full commit SHA** (with a version comment so Dependabot still bumps them). Tags like `@v6` are mutable and can be repointed at malicious code — `changesets/action@v1` was actually a *branch* ref, running in our publish job with `id-token: write`.
2. **Harden `bun install`** — `--frozen-lockfile` everywhere (install exactly the reviewed lockfile), plus `--ignore-scripts` in the privileged release job so dependency lifecycle scripts (the Shai-Hulud propagation vector) can't run next to publish credentials.
3. **Gate the `/snapshot` trigger** in `snapshot.yml` on `author_association` (OWNER/MEMBER/COLLABORATOR) + `startsWith`, so it's no longer triggerable by arbitrary commenters.
4. **Trim permissions** — drop unused `issues: write` from `publish.yml`; replace the dead top-level `pull-requests: write` in `linters.yml` with `contents: read`.
5. **Remove the third-party `LouisBrunner/checks-action`** in favor of a native `$GITHUB_STEP_SUMMARY` write — no third-party dep, no token, and drops `checks: write` from the lint job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)