### PR TITLE
Fix @kyselyType not overriding enums

### DIFF
--- a/src/helpers/generateModel.test.ts
+++ b/src/helpers/generateModel.test.ts
@@ -263,3 +263,86 @@ test("it types enum arrays as strings (#107)", () => {
     permissions: string;
 };`);
 });
+
+test("@kyselyType can override enums", () => {
+  const model = generateModel(
+    {
+      name: "User",
+      fields: [
+        {
+          name: "id",
+          isId: true,
+          isGenerated: false,
+          kind: "scalar",
+          type: "String",
+          hasDefaultValue: false,
+          isList: false,
+          isReadOnly: false,
+          isRequired: true,
+          isUnique: false,
+        },
+        {
+          name: "role",
+          isId: false,
+          isGenerated: false,
+          kind: "enum",
+          type: "Role",
+          hasDefaultValue: false,
+          isList: false,
+          isReadOnly: false,
+          isRequired: true,
+          isUnique: false,
+          documentation: "@kyselyType(SomethingElse)",
+        },
+        {
+          name: "permissions",
+          isId: false,
+          isGenerated: false,
+          kind: "enum",
+          type: "Permission",
+          hasDefaultValue: false,
+          isList: true,
+          isReadOnly: false,
+          isRequired: true,
+          isUnique: false,
+          documentation: "@kyselyType(SomethingElse[])",
+        },
+      ],
+      schema: null,
+      primaryKey: null,
+      dbName: null,
+      uniqueFields: [],
+      uniqueIndexes: [],
+    },
+    {
+      databaseProvider: "postgresql",
+      fileName: "",
+      enumFileName: "",
+      camelCase: false,
+      readOnlyIds: false,
+      groupBySchema: false,
+      defaultSchema: "public",
+      dbTypeName: "DB",
+      importExtension: "",
+      exportWrappedTypes: false,
+    },
+    {
+      groupBySchema: false,
+      defaultSchema: "public",
+    }
+  );
+
+  const source = stringifyTsNode(model.definition);
+
+  expect(source).toEqual(`export type User = {
+    id: string;
+    /**
+     * @kyselyType(SomethingElse)
+     */
+    role: SomethingElse;
+    /**
+     * @kyselyType(SomethingElse[])
+     */
+    permissions: SomethingElse[];
+};`);
+});

--- a/src/helpers/generateModel.ts
+++ b/src/helpers/generateModel.ts
@@ -68,16 +68,19 @@ export const generateModel = (
       return generateField({
         isId: field.isId,
         name: normalizeCase(dbName || field.name, config),
-        type: isEnumArray
-          ? ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
-          : ts.factory.createTypeReferenceNode(
-              ts.factory.createIdentifier(
-                schemaPrefix && defaultSchema !== schemaPrefix
-                  ? `${capitalize(schemaPrefix)}.${field.type}`
-                  : field.type
-              ),
-              undefined
-            ),
+        type:
+          typeOverride !== null
+            ? ts.factory.createTypeReferenceNode(typeOverride)
+            : isEnumArray
+              ? ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
+              : ts.factory.createTypeReferenceNode(
+                  ts.factory.createIdentifier(
+                    schemaPrefix && defaultSchema !== schemaPrefix
+                      ? `${capitalize(schemaPrefix)}.${field.type}`
+                      : field.type
+                  ),
+                  undefined
+                ),
         nullable: !field.isRequired,
         generated: isGenerated,
         list: false,


### PR DESCRIPTION
Hello!

This should fix `@kyselyType(Something)` adding a comment but not actually overriding the type for enums.

I'm using `PGliteDialect` from `kysely` and kysely correctly returns an array of strings when querying for an array of enums (not a simple string), this is why I need an override.