### PR TITLE
Fix camelCase for ALL_CAPS database names

### DIFF
--- a/.changeset/brown-buckets-camelcase.md
+++ b/.changeset/brown-buckets-camelcase.md
@@ -1,0 +1,9 @@
+---
+"prisma-kysely": patch
+---
+
+Fix `camelCase = true` for all-uppercase mapped table and column names.
+
+Previously names such as `UPDATED_AT`, `ID`, or `TEST_CUSTOMERS` could be emitted as `UPDATEDAT`, `ID`, and `TESTCUSTOMERS` because the camel-case mapper preserved uppercase segments instead of normalizing all-uppercase snake-case identifiers first. This affected schemas that map database names with uppercase conventions through Prisma `@map` and `@@map`.
+
+The generator now treats all-uppercase snake-case names as database identifiers that should be lowercased before camel-case conversion. With `camelCase = true`, `UPDATED_AT` becomes `updatedAt`, `ID` becomes `id`, and `TEST_CUSTOMERS` becomes `testCustomers`, matching the behavior users expect from Kysely's camel case plugin.

--- a/.changeset/brown-buckets-camelcase.md
+++ b/.changeset/brown-buckets-camelcase.md
@@ -1,9 +1,14 @@
 ---
-"prisma-kysely": patch
+"prisma-kysely": minor
 ---
 
-Fix `camelCase = true` for all-uppercase mapped table and column names.
+Fix `camelCase = true` for all-uppercase database names (#113).
 
-Previously names such as `UPDATED_AT`, `ID`, or `TEST_CUSTOMERS` could be emitted as `UPDATEDAT`, `ID`, and `TESTCUSTOMERS` because the camel-case mapper preserved uppercase segments instead of normalizing all-uppercase snake-case identifiers first. This affected schemas that map database names with uppercase conventions through Prisma `@map` and `@@map`.
+Mapped names such as `UPDATED_AT`, `ID`, or `TEST_CUSTOMERS` were emitted as
+`UPDATEDAT`, `ID`, and `TESTCUSTOMERS`. They now become `updatedAt`, `id`, and
+`testCustomers`.
 
-The generator now treats all-uppercase snake-case names as database identifiers that should be lowercased before camel-case conversion. With `camelCase = true`, `UPDATED_AT` becomes `updatedAt`, `ID` becomes `id`, and `TEST_CUSTOMERS` becomes `testCustomers`, matching the behavior users expect from Kysely's camel case plugin.
+This matches Kysely's `new CamelCasePlugin({ upperCase: true })`. If your
+database uses ALL_CAPS names, pass `upperCase: true` to the plugin so the
+generated types match the row keys at runtime. Lowercase snake_case names are
+unaffected either way.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ hope it's just as useful for you! 😎
 | `fileName`               | The filename for the generated file                                                                                                                                                                                                                                                                                                                                                 | `types.ts` |
 | `importExtension`        | The extension to append to imports. E.g: `".js"` or `".ts"`. Use `""` to append nothing.                                                                                                                                                                                                                                                                                            | `""`       |
 | `enumFileName`           | The filename for the generated enums. Omitting this will generate enums and files in the same file. Cannot be combined with `groupBySchema`.                                                                                                                                                                                                                                        |            |
-| `camelCase`              | Enable support for Kysely's camelCase plugin                                                                                                                                                                                                                                                                                                                                        | `false`    |
+| `camelCase`              | Match Kysely's `CamelCasePlugin`. See [camelCase](#camelcase).                                                                                                                                                                                                                                                                                                                      | `false`    |
 | `exportWrappedTypes`     | Kysely wrapped types such as `Selectable<Model>` are also exported as described in the [Kysely documentation](https://kysely.dev/docs/getting-started#types). The exported types follow the naming conventions of the document.                                                                                                                                                     | `false`    |
 | `banner`                 | Content to prepend to the start of generated file(s). Useful for custom imports, pragma directives (e.g., `// @ts-nocheck`), comments, or any other content. Supports single-line strings or multi-line via Prisma triple-quoted strings (`""" ... """`). The content is inserted verbatim at the top of the file(s).                                                               |            |
 | `readOnlyIds`            | Use Kysely's `GeneratedAlways` for `@id` fields with default values, preventing insert and update.                                                                                                                                                                                                                                                                                  | `false`    |
@@ -169,6 +169,20 @@ export type Dog = {
 `groupBySchema = "module"` is the recommended option for new projects. In the
 next major version, `groupBySchema` will be removed and multi-schema projects
 will always emit one file per schema.
+
+### camelCase
+
+If you use Kysely's `CamelCasePlugin`, set `camelCase = true` so the generated
+types match what the plugin does at runtime:
+
+| `schema.prisma`      | your Kysely setup                          |
+| :------------------- | :----------------------------------------- |
+| _(unset)_ or `false` | no plugin                                  |
+| `camelCase = true`   | `new CamelCasePlugin({ upperCase: true })` |
+
+`upperCase: true` makes the plugin handle ALL_CAPS database names, e.g.
+`UPDATED_AT` → `updatedAt`. It has no effect on lowercase snake_case names, so
+it is safe to always pass.
 
 ### PostgreSQL enum arrays
 

--- a/src/helpers/generateDatabaseType.test.ts
+++ b/src/helpers/generateDatabaseType.test.ts
@@ -38,6 +38,7 @@ test("it respects camelCase option names", () => {
     [
       { tableName: "book_mark", typeName: "Bookmark" },
       { tableName: "session", typeName: "Session" },
+      { tableName: "TEST_CUSTOMERS", typeName: "Customer" },
       { tableName: "user_table", typeName: "User" },
     ],
     {
@@ -58,6 +59,7 @@ test("it respects camelCase option names", () => {
   expect(result).toEqual(`export type DB = {
     bookMark: Bookmark;
     session: Session;
+    testCustomers: Customer;
     userTable: User;
 };`);
 });

--- a/src/helpers/generateModel.test.ts
+++ b/src/helpers/generateModel.test.ts
@@ -151,6 +151,19 @@ test("it respects camelCase option", () => {
           isRequired: false,
           isUnique: false,
         },
+        {
+          name: "updatedAt",
+          dbName: "UPDATED_AT",
+          isId: false,
+          isGenerated: false,
+          kind: "scalar",
+          type: "DateTime",
+          hasDefaultValue: false,
+          isList: false,
+          isReadOnly: false,
+          isRequired: true,
+          isUnique: false,
+        },
       ],
       schema: null,
       primaryKey: null,
@@ -184,6 +197,7 @@ test("it respects camelCase option", () => {
   expect(source).toEqual(`export type User = {
     id: string;
     userName: string | null;
+    updatedAt: string;
 };`);
 });
 

--- a/src/utils/normalizeCase.test.ts
+++ b/src/utils/normalizeCase.test.ts
@@ -21,6 +21,25 @@ test("converts names to camel case when config value is set", () => {
   expect(newName).toEqual("userId");
 });
 
+test("converts all-uppercase mapped names to camel case when config value is set", () => {
+  const config = {
+    camelCase: true,
+    databaseProvider: "postgresql",
+    fileName: "",
+    enumFileName: "",
+    readOnlyIds: false,
+    groupBySchema: GroupBySchema.None,
+    defaultSchema: "public",
+    dbTypeName: "DB",
+    importExtension: "",
+    exportWrappedTypes: false,
+  } as const;
+
+  expect(normalizeCase("UPDATED_AT", config)).toEqual("updatedAt");
+  expect(normalizeCase("ID", config)).toEqual("id");
+  expect(normalizeCase("TEST_CUSTOMERS", config)).toEqual("testCustomers");
+});
+
 test("doesn't convert names to camel case when config value isn't set", () => {
   const originalName = "user_id";
   const newName = normalizeCase(originalName, {

--- a/src/utils/normalizeCase.ts
+++ b/src/utils/normalizeCase.ts
@@ -1,7 +1,7 @@
 import type { Config } from "./validateConfig.ts";
 import { createCamelCaseMapper } from "./words.ts";
 
-const snakeToCamel = createCamelCaseMapper();
+const snakeToCamel = createCamelCaseMapper({ upperCase: true });
 
 export const normalizeCase = (name: string, config: Config) => {
   if (!config.camelCase) return name;

--- a/src/utils/words.ts
+++ b/src/utils/words.ts
@@ -1,5 +1,5 @@
 // Copied directly from the Kysely repo
-// https://github.com/koskimas/kysely/blob/a8e28d9edd6284d5410f93bc24d3c6252add6ea1/src/plugin/camel-case/camel-case.ts
+// https://github.com/kysely-org/kysely/blob/c4316777c13a6ed6f8645bffe19f0e763682cf04/src/plugin/camel-case/camel-case.ts
 
 export type StringMapper = (str: string) => string;
 
@@ -34,7 +34,12 @@ export function createSnakeCaseMapper({
       // If underScoreBeforeDigits is true then, well, insert an underscore
       // before digits :). Only the first digit gets an underscore if
       // there are multiple.
-      if (underscoreBeforeDigits && isDigit(char) && !isDigit(prevChar)) {
+      if (
+        underscoreBeforeDigits &&
+        isDigit(char) &&
+        !isDigit(prevChar) &&
+        !out.endsWith("_")
+      ) {
         out += "_" + char;
         continue;
       }


### PR DESCRIPTION
`camelCase = true` now turns `UPDATED_AT` into `updatedAt` instead of `UPDATEDAT`. Pair it with `new CamelCasePlugin({ upperCase: true })`. Fixes #113. Work by @arthurfiorette, split from #189.