### PR TITLE
Remove unsupportedTypeOverride

### DIFF
--- a/.changeset/remove-unsupported-type-override.md
+++ b/.changeset/remove-unsupported-type-override.md
@@ -1,0 +1,7 @@
+---
+"prisma-kysely": patch
+---
+
+Remove `unsupportedTypeOverride`. It never had any effect: `Unsupported(...)`
+fields are skipped by the generator before the override is consulted. If you
+have it in your `schema.prisma`, delete the line.

--- a/src/helpers/generateFieldType.test.ts
+++ b/src/helpers/generateFieldType.test.ts
@@ -14,7 +14,6 @@ test("it respects overrides when generating field types", () => {
     floatTypeOverride: "sink",
     intTypeOverride: "lol",
     jsonTypeOverride: "freddy",
-    unsupportedTypeOverride: "valid",
   };
 
   const config: Config = {
@@ -41,7 +40,6 @@ test("it respects overrides when generating field types", () => {
     "Float",
     "Int",
     "Json",
-    "Unsupported",
   ];
 
   expect(

--- a/src/helpers/generateFieldType.ts
+++ b/src/helpers/generateFieldType.ts
@@ -86,8 +86,6 @@ export const overrideType = (type: string, config: Config) => {
       return config.bytesTypeOverride;
     case "Json":
       return config.jsonTypeOverride;
-    case "Unsupported":
-      return config.unsupportedTypeOverride;
   }
 };
 

--- a/src/utils/validateConfig.ts
+++ b/src/utils/validateConfig.ts
@@ -42,7 +42,6 @@ export const configValidator = z
     dateTimeTypeOverride: z.string().optional(),
     jsonTypeOverride: z.string().optional(),
     bytesTypeOverride: z.string().optional(),
-    unsupportedTypeOverride: z.string().optional(),
 
     // The DB type name to use in the generated types.
     dbTypeName: z.string().default("DB"),


### PR DESCRIPTION
This option never did anything. `Unsupported()` fields are skipped before it is read. Part of #200.